### PR TITLE
[feat] 주문 상세 조회 API 구현

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,7 +1,7 @@
 language: "ko-KR"
 
 reviews:
-  profile: "assertive"
+  profile: "chill"
   request_changes_workflow: true
   high_level_summary: true
   poem: false

--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,8 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	testAnnotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.testcontainers:postgresql'
+	testImplementation 'org.mockito:mockito-core'
+	testImplementation 'net.bytebuddy:byte-buddy-agent'
 }
 
 dependencyManagement {
@@ -61,5 +63,9 @@ spotless {
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+tasks.withType(Test).configureEach {
+	jvmArgs "-javaagent:${configurations.testRuntimeClasspath.find { it.name.contains('byte-buddy-agent') }}"
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ dependencies {
 	testAnnotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.testcontainers:postgresql'
 	testImplementation 'org.mockito:mockito-core'
-	testImplementation 'net.bytebuddy:byte-buddy-agent'
+	testRuntimeOnly  'net.bytebuddy:byte-buddy-agent'
 }
 
 dependencyManagement {
@@ -66,6 +66,10 @@ tasks.named('test') {
 }
 
 tasks.withType(Test).configureEach {
-	jvmArgs "-javaagent:${configurations.testRuntimeClasspath.find { it.name.contains('byte-buddy-agent') }}"
+	def byteBuddyAgent = configurations.testRuntimeClasspath.files.find { it.name.startsWith('byte-buddy-agent-') }
+		if (byteBuddyAgent == null) {
+			throw new GradleException("byte-buddy-agent를 testRuntimeClasspath에서 찾을 수 없습니다.")
+		}
+	jvmArgs "-javaagent:${byteBuddyAgent.absolutePath}"
 }
 

--- a/http/http-client.env.json
+++ b/http/http-client.env.json
@@ -1,0 +1,7 @@
+{
+  "local": {
+    "host": "localhost:9007",
+    "userId": "550e8400-e29b-41d4-a716-446655440003",
+    "orderId": "6129d32b-ee8b-4871-8a2b-b684d1c1a913"
+  }
+}

--- a/http/init.sql
+++ b/http/init.sql
@@ -32,21 +32,22 @@ DO $$
 
                 v_discount := CASE WHEN random() > 0.5 THEN (v_total_price * 0.1)::bigint ELSE 0 END;
 
-                INSERT INTO p_order (
+                INSERT INTO order_db.p_order (
                     id, student_id, student_name, original_price, discount_amount, final_price,
                     status, created_at, updated_at, created_by, updated_by,
-                    coupon_discount_rate, coupon_name, coupon_code
+                    coupon_id, coupon_discount_rate, coupon_name, coupon_code
                 ) VALUES (
                              v_order_id, user_ids[v_user_idx], user_names[v_user_idx], v_total_price, v_discount, v_total_price - v_discount,
                              (ARRAY['PAYMENT_PENDING', 'PAID', 'COMPLETED', 'CANCELED'])[floor(random()*4)+1],
                              now(), now(), user_ids[v_user_idx], user_ids[v_user_idx],
-                             CASE WHEN v_discount > 0 THEN 10.00 ELSE 0 END,
+                             CASE WHEN v_discount > 0 THEN gen_random_uuid() ELSE NULL END, -- coupon_id 추가
+                             CASE WHEN v_discount > 0 THEN 10.00 ELSE NULL END,             -- 0 대신 NULL 처리
                              CASE WHEN v_discount > 0 THEN '신규 가입 감사 쿠폰' ELSE NULL END,
                              CASE WHEN v_discount > 0 THEN 'WELCOME_2026' ELSE NULL END
                          );
 
                 FOR j IN 1..v_item_count LOOP
-                        INSERT INTO p_order_item (
+                        INSERT INTO order_db.p_order_item (
                             id, order_id, product_id, instructor_id, instructor_name,
                             product_name, product_price, product_type, status,
                             created_at, updated_at, created_by, updated_by

--- a/http/init.sql
+++ b/http/init.sql
@@ -1,0 +1,61 @@
+DO $$
+    DECLARE
+        user_ids uuid[] := ARRAY[
+            '550e8400-e29b-41d4-a716-446655440000', '550e8400-e29b-41d4-a716-446655440001',
+            '550e8400-e29b-41d4-a716-446655440002', '550e8400-e29b-41d4-a716-446655440003',
+            '550e8400-e29b-41d4-a716-446655440004'
+            ];
+        user_names varchar[] := ARRAY['신혜원', '이호영', '김시온', '한소연', '하지혜'];
+        v_order_id uuid;
+        v_user_idx int;
+        v_item_count int;
+        v_total_price bigint;
+        v_discount bigint;
+        v_item_prices bigint[];
+        i int; j int;
+    BEGIN
+        FOR i IN 1..50 LOOP
+                v_order_id := gen_random_uuid();
+                v_user_idx := (floor(random() * 5) + 1)::int;
+                v_item_count := (floor(random() * 4) + 1)::int;
+                v_total_price := 0;
+                v_item_prices := '{}';
+
+                FOR j IN 1..v_item_count LOOP
+                        DECLARE
+                            v_p bigint := (floor(random() * 10) + 1) * 10000;
+                        BEGIN
+                            v_item_prices := array_append(v_item_prices, v_p);
+                            v_total_price := v_total_price + v_p;
+                        END;
+                    END LOOP;
+
+                v_discount := CASE WHEN random() > 0.5 THEN (v_total_price * 0.1)::bigint ELSE 0 END;
+
+                INSERT INTO p_order (
+                    id, student_id, student_name, original_price, discount_amount, final_price,
+                    status, created_at, updated_at, created_by, updated_by,
+                    coupon_discount_rate, coupon_name, coupon_code
+                ) VALUES (
+                             v_order_id, user_ids[v_user_idx], user_names[v_user_idx], v_total_price, v_discount, v_total_price - v_discount,
+                             (ARRAY['PAYMENT_PENDING', 'PAID', 'COMPLETED', 'CANCELED'])[floor(random()*4)+1],
+                             now(), now(), user_ids[v_user_idx], user_ids[v_user_idx],
+                             CASE WHEN v_discount > 0 THEN 10.00 ELSE 0 END,
+                             CASE WHEN v_discount > 0 THEN '신규 가입 감사 쿠폰' ELSE NULL END,
+                             CASE WHEN v_discount > 0 THEN 'WELCOME_2026' ELSE NULL END
+                         );
+
+                FOR j IN 1..v_item_count LOOP
+                        INSERT INTO p_order_item (
+                            id, order_id, product_id, instructor_id, instructor_name,
+                            product_name, product_price, product_type, status,
+                            created_at, updated_at, created_by, updated_by
+                        ) VALUES (
+                                     gen_random_uuid(), v_order_id, gen_random_uuid(), gen_random_uuid(), '강사_' || j,
+                                     '상품 ' || i || '-' || j, v_item_prices[j],
+                                     (ARRAY['COURSE', 'MENTORING'])[floor(random()*2)+1], 'ACTIVE',
+                                     now(), now(), user_ids[v_user_idx], user_ids[v_user_idx]
+                                 );
+                    END LOOP;
+            END LOOP;
+    END $$;

--- a/http/order.http
+++ b/http/order.http
@@ -1,0 +1,3 @@
+### 주문 상세 조회
+GET http://{{host}}/api/v1/orders/{{orderId}}
+X-User-Id: {{userId}}

--- a/src/main/java/com/goggles/orderservice/application/dto/command/CreateOrderItemCommand.java
+++ b/src/main/java/com/goggles/orderservice/application/dto/command/CreateOrderItemCommand.java
@@ -3,6 +3,4 @@ package com.goggles.orderservice.application.dto.command;
 import com.goggles.orderservice.domain.vo.Instructor;
 import com.goggles.orderservice.domain.vo.Product;
 
-public record CreateOrderItemCommand(
-    Product product, Instructor instructor
-) {}
+public record CreateOrderItemCommand(Product product, Instructor instructor) {}

--- a/src/main/java/com/goggles/orderservice/application/dto/command/CreateOrderItemCommand.java
+++ b/src/main/java/com/goggles/orderservice/application/dto/command/CreateOrderItemCommand.java
@@ -1,0 +1,8 @@
+package com.goggles.orderservice.application.dto.command;
+
+import com.goggles.orderservice.domain.vo.Instructor;
+import com.goggles.orderservice.domain.vo.Product;
+
+public record CreateOrderItemCommand(
+    Product product, Instructor instructor
+) {}

--- a/src/main/java/com/goggles/orderservice/application/dto/query/OrderListQuery.java
+++ b/src/main/java/com/goggles/orderservice/application/dto/query/OrderListQuery.java
@@ -1,0 +1,3 @@
+package com.goggles.orderservice.application.dto.query;
+
+public record OrderListQuery() {}

--- a/src/main/java/com/goggles/orderservice/application/dto/result/OrderDetailResult.java
+++ b/src/main/java/com/goggles/orderservice/application/dto/result/OrderDetailResult.java
@@ -1,0 +1,37 @@
+package com.goggles.orderservice.application.dto.result;
+
+import com.goggles.orderservice.domain.entity.Order;
+import com.goggles.orderservice.domain.enums.OrderStatus;
+import com.goggles.orderservice.domain.vo.Coupon;
+import com.goggles.orderservice.domain.vo.OrderPrice;
+import com.goggles.orderservice.domain.vo.Orderer;
+import com.goggles.orderservice.domain.vo.Payment;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+public record OrderDetailResult(
+    UUID orderId,
+    Orderer orderer,
+    Coupon coupon,
+    OrderPrice price,
+    Payment payment,
+    LocalDateTime createdAt,
+    OrderStatus status,
+    List<OrderItemSummary> orderItems
+) {
+  public static OrderDetailResult from(Order order) {
+    return new OrderDetailResult(
+        order.getId(),
+        order.getOrderer(),
+        order.getCoupon(),
+        order.getPrice(),
+        order.getPayment(),
+        order.getCreatedAt(),
+        order.getStatus(),
+        order.getItems().stream()
+            .map(OrderItemSummary::from)
+            .toList()
+    );
+  }
+}

--- a/src/main/java/com/goggles/orderservice/application/dto/result/OrderDetailResult.java
+++ b/src/main/java/com/goggles/orderservice/application/dto/result/OrderDetailResult.java
@@ -18,8 +18,7 @@ public record OrderDetailResult(
     Payment payment,
     LocalDateTime createdAt,
     OrderStatus status,
-    List<OrderItemSummary> orderItems
-) {
+    List<OrderItemSummary> orderItems) {
   public static OrderDetailResult from(Order order) {
     return new OrderDetailResult(
         order.getId(),
@@ -29,9 +28,6 @@ public record OrderDetailResult(
         order.getPayment(),
         order.getCreatedAt(),
         order.getStatus(),
-        order.getItems().stream()
-            .map(OrderItemSummary::from)
-            .toList()
-    );
+        order.getItems().stream().map(OrderItemSummary::from).toList());
   }
 }

--- a/src/main/java/com/goggles/orderservice/application/dto/result/OrderItemSummary.java
+++ b/src/main/java/com/goggles/orderservice/application/dto/result/OrderItemSummary.java
@@ -7,17 +7,9 @@ import com.goggles.orderservice.domain.vo.Product;
 import java.util.UUID;
 
 public record OrderItemSummary(
-    UUID orderItemId,
-    Product product,
-    Instructor instructor,
-    OrderItemStatus status
-) {
+    UUID orderItemId, Product product, Instructor instructor, OrderItemStatus status) {
   public static OrderItemSummary from(OrderItem item) {
     return new OrderItemSummary(
-        item.getId(),
-        item.getProduct(),
-        item.getInstructor(),
-        item.getStatus()
-    );
+        item.getId(), item.getProduct(), item.getInstructor(), item.getStatus());
   }
 }

--- a/src/main/java/com/goggles/orderservice/application/dto/result/OrderItemSummary.java
+++ b/src/main/java/com/goggles/orderservice/application/dto/result/OrderItemSummary.java
@@ -1,0 +1,23 @@
+package com.goggles.orderservice.application.dto.result;
+
+import com.goggles.orderservice.domain.entity.OrderItem;
+import com.goggles.orderservice.domain.enums.OrderItemStatus;
+import com.goggles.orderservice.domain.vo.Instructor;
+import com.goggles.orderservice.domain.vo.Product;
+import java.util.UUID;
+
+public record OrderItemSummary(
+    UUID orderItemId,
+    Product product,
+    Instructor instructor,
+    OrderItemStatus status
+) {
+  public static OrderItemSummary from(OrderItem item) {
+    return new OrderItemSummary(
+        item.getId(),
+        item.getProduct(),
+        item.getInstructor(),
+        item.getStatus()
+    );
+  }
+}

--- a/src/main/java/com/goggles/orderservice/application/dto/result/OrderListResult.java
+++ b/src/main/java/com/goggles/orderservice/application/dto/result/OrderListResult.java
@@ -1,0 +1,24 @@
+package com.goggles.orderservice.application.dto.result;
+
+import com.goggles.orderservice.domain.entity.Order;
+import com.goggles.orderservice.domain.enums.OrderStatus;
+import com.goggles.orderservice.domain.vo.OrderPrice;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+public record OrderListResult(
+    UUID orderId,
+    OrderPrice price,
+    LocalDateTime createdAt,
+    OrderStatus status,
+    List<OrderItemSummary> orderItems) {
+  public static OrderListResult from(Order order) {
+    return new OrderListResult(
+        order.getId(),
+        order.getPrice(),
+        order.getCreatedAt(),
+        order.getStatus(),
+        order.getItems().stream().map(OrderItemSummary::from).toList());
+  }
+}

--- a/src/main/java/com/goggles/orderservice/application/service/OrderQueryService.java
+++ b/src/main/java/com/goggles/orderservice/application/service/OrderQueryService.java
@@ -1,0 +1,11 @@
+package com.goggles.orderservice.application.service;
+
+import com.goggles.orderservice.application.dto.query.OrderListQuery;
+import com.goggles.orderservice.application.dto.result.OrderDetailResult;
+import com.goggles.orderservice.application.dto.result.OrderListResult;
+import java.util.UUID;
+
+public interface OrderQueryService {
+  OrderDetailResult getOrderDetails(UUID orderId, UUID userId);
+  OrderListResult getOrders(OrderListQuery orderListQuery);
+}

--- a/src/main/java/com/goggles/orderservice/application/service/OrderQueryService.java
+++ b/src/main/java/com/goggles/orderservice/application/service/OrderQueryService.java
@@ -7,5 +7,6 @@ import java.util.UUID;
 
 public interface OrderQueryService {
   OrderDetailResult getOrderDetails(UUID orderId, UUID userId);
+
   OrderListResult getOrders(OrderListQuery orderListQuery);
 }

--- a/src/main/java/com/goggles/orderservice/application/service/impl/OrderQueryServiceImpl.java
+++ b/src/main/java/com/goggles/orderservice/application/service/impl/OrderQueryServiceImpl.java
@@ -20,8 +20,10 @@ public class OrderQueryServiceImpl implements OrderQueryService {
 
   @Override
   public OrderDetailResult getOrderDetails(UUID orderId, UUID userId) {
-    Order order = orderRepository.getOrderByIdAndUserId(orderId, userId)
-        .orElseThrow(() -> new NotFoundException("주문을 찾을 수 없습니다."));
+    Order order =
+        orderRepository
+            .getOrderByIdAndUserId(orderId, userId)
+            .orElseThrow(() -> new NotFoundException("주문을 찾을 수 없습니다."));
 
     return OrderDetailResult.from(order);
   }

--- a/src/main/java/com/goggles/orderservice/application/service/impl/OrderQueryServiceImpl.java
+++ b/src/main/java/com/goggles/orderservice/application/service/impl/OrderQueryServiceImpl.java
@@ -1,0 +1,33 @@
+package com.goggles.orderservice.application.service.impl;
+
+import com.goggles.common.exception.NotFoundException;
+import com.goggles.orderservice.application.dto.query.OrderListQuery;
+import com.goggles.orderservice.application.dto.result.OrderDetailResult;
+import com.goggles.orderservice.application.dto.result.OrderListResult;
+import com.goggles.orderservice.application.service.OrderQueryService;
+import com.goggles.orderservice.domain.entity.Order;
+import com.goggles.orderservice.domain.repository.OrderRepository;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class OrderQueryServiceImpl implements OrderQueryService {
+  private final OrderRepository orderRepository;
+
+  @Override
+  public OrderDetailResult getOrderDetails(UUID orderId, UUID userId) {
+    Order order = orderRepository.getOrderByIdAndUserId(orderId, userId)
+        .orElseThrow(() -> new NotFoundException("주문을 찾을 수 없습니다."));
+
+    return OrderDetailResult.from(order);
+  }
+
+  @Override
+  public OrderListResult getOrders(OrderListQuery orderListQuery) {
+    return null;
+  }
+}

--- a/src/main/java/com/goggles/orderservice/domain/entity/Order.java
+++ b/src/main/java/com/goggles/orderservice/domain/entity/Order.java
@@ -8,9 +8,11 @@ import com.goggles.orderservice.application.dto.command.CreateOrderItemCommand;
 import com.goggles.orderservice.domain.enums.OrderItemStatus;
 import com.goggles.orderservice.domain.enums.OrderStatus;
 import com.goggles.orderservice.domain.vo.Coupon;
+import com.goggles.orderservice.domain.vo.Instructor;
 import com.goggles.orderservice.domain.vo.OrderPrice;
 import com.goggles.orderservice.domain.vo.Orderer;
 import com.goggles.orderservice.domain.vo.Payment;
+import com.goggles.orderservice.domain.vo.Product;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
@@ -38,7 +40,7 @@ import org.hibernate.annotations.UuidGenerator;
 @SQLRestriction("deleted_at IS NULL")
 public class Order extends BaseAudit {
 
-  @Id @GeneratedValue @UuidGenerator private UUID id;
+  @Id @GeneratedValue @UuidGenerator private UUID id = UUID.randomUUID();
 
   @Embedded private Orderer orderer;
 
@@ -61,13 +63,7 @@ public class Order extends BaseAudit {
   }
 
   public static Order create(
-      Orderer orderer, Coupon coupon, OrderPrice price, List<CreateOrderItemCommand> itemCommands) {
-
-    List<OrderItem> items =
-        itemCommands.stream()
-            .map(cmd -> OrderItem.create(cmd.product(), cmd.instructor()))
-            .toList();
-
+      Orderer orderer, Coupon coupon, OrderPrice price, List<OrderItem> items) {
     validateItems(items);
     Order order = new Order();
     order.orderer = orderer;
@@ -79,6 +75,10 @@ public class Order extends BaseAudit {
     }
 
     return order;
+  }
+
+  public static OrderItem createItem(Product product, Instructor instructor) {
+    return OrderItem.create(product, instructor);
   }
 
   public void pay(String paymentKey, String paymentName) {

--- a/src/main/java/com/goggles/orderservice/domain/entity/Order.java
+++ b/src/main/java/com/goggles/orderservice/domain/entity/Order.java
@@ -39,7 +39,7 @@ import org.hibernate.annotations.UuidGenerator;
 @SQLRestriction("deleted_at IS NULL")
 public class Order extends BaseAudit {
 
-  @Id @GeneratedValue @UuidGenerator private UUID id = UUID.randomUUID();
+  @Id @GeneratedValue @UuidGenerator private UUID id;
 
   @Embedded private Orderer orderer;
 

--- a/src/main/java/com/goggles/orderservice/domain/entity/Order.java
+++ b/src/main/java/com/goggles/orderservice/domain/entity/Order.java
@@ -41,11 +41,11 @@ public class Order extends BaseAudit {
 
   @Embedded private Orderer orderer;
 
-  @Embedded private Coupon coupon;
+  @Embedded private Coupon coupon = null;
 
   @Embedded private OrderPrice price;
 
-  @Embedded private Payment payment;
+  @Embedded private Payment payment = null;
 
   @Enumerated(EnumType.STRING)
   @Column(name = "status", nullable = false, length = 20)

--- a/src/main/java/com/goggles/orderservice/domain/entity/Order.java
+++ b/src/main/java/com/goggles/orderservice/domain/entity/Order.java
@@ -4,7 +4,6 @@ import com.goggles.common.domain.BaseAudit;
 import com.goggles.common.exception.BadRequestException;
 import com.goggles.common.exception.ConflictException;
 import com.goggles.common.exception.NotFoundException;
-import com.goggles.orderservice.application.dto.command.CreateOrderItemCommand;
 import com.goggles.orderservice.domain.enums.OrderItemStatus;
 import com.goggles.orderservice.domain.enums.OrderStatus;
 import com.goggles.orderservice.domain.vo.Coupon;

--- a/src/main/java/com/goggles/orderservice/domain/entity/Order.java
+++ b/src/main/java/com/goggles/orderservice/domain/entity/Order.java
@@ -4,6 +4,7 @@ import com.goggles.common.domain.BaseAudit;
 import com.goggles.common.exception.BadRequestException;
 import com.goggles.common.exception.ConflictException;
 import com.goggles.common.exception.NotFoundException;
+import com.goggles.orderservice.application.dto.command.CreateOrderItemCommand;
 import com.goggles.orderservice.domain.enums.OrderItemStatus;
 import com.goggles.orderservice.domain.enums.OrderStatus;
 import com.goggles.orderservice.domain.vo.Coupon;
@@ -60,7 +61,12 @@ public class Order extends BaseAudit {
   }
 
   public static Order create(
-      Orderer orderer, Coupon coupon, OrderPrice price, List<OrderItem> items) {
+      Orderer orderer, Coupon coupon, OrderPrice price, List<CreateOrderItemCommand> itemCommands) {
+
+    List<OrderItem> items = itemCommands.stream()
+        .map(cmd -> OrderItem.create(cmd.product(), cmd.instructor()))
+        .toList();
+
     validateItems(items);
     Order order = new Order();
     order.orderer = orderer;

--- a/src/main/java/com/goggles/orderservice/domain/entity/Order.java
+++ b/src/main/java/com/goggles/orderservice/domain/entity/Order.java
@@ -63,9 +63,10 @@ public class Order extends BaseAudit {
   public static Order create(
       Orderer orderer, Coupon coupon, OrderPrice price, List<CreateOrderItemCommand> itemCommands) {
 
-    List<OrderItem> items = itemCommands.stream()
-        .map(cmd -> OrderItem.create(cmd.product(), cmd.instructor()))
-        .toList();
+    List<OrderItem> items =
+        itemCommands.stream()
+            .map(cmd -> OrderItem.create(cmd.product(), cmd.instructor()))
+            .toList();
 
     validateItems(items);
     Order order = new Order();

--- a/src/main/java/com/goggles/orderservice/domain/entity/OrderItem.java
+++ b/src/main/java/com/goggles/orderservice/domain/entity/OrderItem.java
@@ -30,7 +30,7 @@ import org.hibernate.annotations.UuidGenerator;
 @SQLRestriction("deleted_at IS NULL")
 public class OrderItem extends BaseAudit {
 
-  @Id @GeneratedValue @UuidGenerator private UUID id = UUID.randomUUID();
+  @Id @GeneratedValue @UuidGenerator private UUID id;
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "order_id", nullable = false, updatable = false)

--- a/src/main/java/com/goggles/orderservice/domain/entity/OrderItem.java
+++ b/src/main/java/com/goggles/orderservice/domain/entity/OrderItem.java
@@ -30,7 +30,7 @@ import org.hibernate.annotations.UuidGenerator;
 @SQLRestriction("deleted_at IS NULL")
 public class OrderItem extends BaseAudit {
 
-  @Id @GeneratedValue @UuidGenerator private UUID id;
+  @Id @GeneratedValue @UuidGenerator private UUID id = UUID.randomUUID();
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "order_id", nullable = false, updatable = false)

--- a/src/main/java/com/goggles/orderservice/domain/enums/OrderItemStatus.java
+++ b/src/main/java/com/goggles/orderservice/domain/enums/OrderItemStatus.java
@@ -1,6 +1,25 @@
 package com.goggles.orderservice.domain.enums;
 
+import java.util.EnumSet;
+import java.util.Set;
+
 public enum OrderItemStatus {
-  ACTIVE,
-  CANCELED
+  ACTIVE{
+    @Override
+    public Set<OrderItemStatus> allowedTransitions() {
+      return EnumSet.of(CANCELED);
+    }
+  },
+  CANCELED{
+    @Override
+    public Set<OrderItemStatus> allowedTransitions() {
+      return EnumSet.noneOf(OrderItemStatus.class);
+    }
+  };
+
+  public abstract Set<OrderItemStatus> allowedTransitions();
+
+  public boolean canTransitionTo(OrderItemStatus next) {
+    return allowedTransitions().contains(next);
+  }
 }

--- a/src/main/java/com/goggles/orderservice/domain/enums/OrderItemStatus.java
+++ b/src/main/java/com/goggles/orderservice/domain/enums/OrderItemStatus.java
@@ -4,13 +4,13 @@ import java.util.EnumSet;
 import java.util.Set;
 
 public enum OrderItemStatus {
-  ACTIVE{
+  ACTIVE {
     @Override
     public Set<OrderItemStatus> allowedTransitions() {
       return EnumSet.of(CANCELED);
     }
   },
-  CANCELED{
+  CANCELED {
     @Override
     public Set<OrderItemStatus> allowedTransitions() {
       return EnumSet.noneOf(OrderItemStatus.class);

--- a/src/main/java/com/goggles/orderservice/domain/repository/OrderRepository.java
+++ b/src/main/java/com/goggles/orderservice/domain/repository/OrderRepository.java
@@ -1,3 +1,9 @@
 package com.goggles.orderservice.domain.repository;
 
-public interface OrderRepository {}
+import com.goggles.orderservice.domain.entity.Order;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface OrderRepository {
+  Optional<Order> getOrderByIdAndUserId(UUID orderId, UUID userId);
+}

--- a/src/main/java/com/goggles/orderservice/domain/vo/Coupon.java
+++ b/src/main/java/com/goggles/orderservice/domain/vo/Coupon.java
@@ -27,7 +27,8 @@ public class Coupon {
   @Column(name = "coupon_discount_rate", precision = 5, scale = 2)
   private BigDecimal couponDiscountRate;
 
-  public Coupon(UUID couponId, String couponCode, String couponName, BigDecimal couponDiscountRate) {
+  public Coupon(
+      UUID couponId, String couponCode, String couponName, BigDecimal couponDiscountRate) {
     validate(couponId, couponCode, couponName, couponDiscountRate);
     this.couponId = couponId;
     this.couponCode = couponCode;
@@ -35,7 +36,8 @@ public class Coupon {
     this.couponDiscountRate = couponDiscountRate;
   }
 
-  private static void validate(UUID couponId, String couponCode, String couponName, BigDecimal couponDiscountRate) {
+  private static void validate(
+      UUID couponId, String couponCode, String couponName, BigDecimal couponDiscountRate) {
     boolean hasId = couponId != null;
     boolean hasCode = couponCode != null && !couponCode.isBlank();
     boolean hasName = couponName != null && !couponName.isBlank();

--- a/src/main/java/com/goggles/orderservice/domain/vo/Coupon.java
+++ b/src/main/java/com/goggles/orderservice/domain/vo/Coupon.java
@@ -18,25 +18,30 @@ public class Coupon {
   @Column(name = "coupon_id")
   private UUID couponId;
 
+  @Column(name = "coupon_code")
+  private String couponCode;
+
   @Column(name = "coupon_name", length = 100)
   private String couponName;
 
   @Column(name = "coupon_discount_rate", precision = 5, scale = 2)
   private BigDecimal couponDiscountRate;
 
-  public Coupon(UUID couponId, String couponName, BigDecimal couponDiscountRate) {
-    validate(couponId, couponName, couponDiscountRate);
+  public Coupon(UUID couponId, String couponCode, String couponName, BigDecimal couponDiscountRate) {
+    validate(couponId, couponCode, couponName, couponDiscountRate);
     this.couponId = couponId;
+    this.couponCode = couponCode;
     this.couponName = couponName;
     this.couponDiscountRate = couponDiscountRate;
   }
 
-  private static void validate(UUID couponId, String couponName, BigDecimal couponDiscountRate) {
+  private static void validate(UUID couponId, String couponCode, String couponName, BigDecimal couponDiscountRate) {
     boolean hasId = couponId != null;
+    boolean hasCode = couponCode != null && !couponCode.isBlank();
     boolean hasName = couponName != null && !couponName.isBlank();
 
-    if (hasId != hasName) {
-      throw new BadRequestException("couponId와 couponName은 함께 존재하거나 함께 없어야 합니다.");
+    if (hasId != hasCode || hasId != hasName) {
+      throw new BadRequestException("couponId, couponCode, couponName은 함께 존재하거나 함께 없어야 합니다.");
     }
 
     if (hasId && couponDiscountRate == null) {

--- a/src/main/java/com/goggles/orderservice/domain/vo/OrderPrice.java
+++ b/src/main/java/com/goggles/orderservice/domain/vo/OrderPrice.java
@@ -3,7 +3,6 @@ package com.goggles.orderservice.domain.vo;
 import com.goggles.common.exception.BadRequestException;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
-import java.math.BigDecimal;
 import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -16,32 +15,32 @@ import lombok.NoArgsConstructor;
 public class OrderPrice {
 
   @Column(name = "original_price", nullable = false)
-  private BigDecimal originalPrice;
+  private Long originalPrice;
 
   @Column(name = "discount_amount", nullable = false)
-  private BigDecimal discountAmount;
+  private Long discountAmount;
 
   @Column(name = "final_price", nullable = false)
-  private BigDecimal finalPrice;
+  private Long finalPrice;
 
-  public OrderPrice(BigDecimal originalPrice, BigDecimal discountAmount) {
+  public OrderPrice(Long originalPrice, Long discountAmount) {
     validate(originalPrice, discountAmount);
     this.originalPrice = originalPrice;
     this.discountAmount = discountAmount;
-    this.finalPrice = originalPrice.subtract(discountAmount);
+    this.finalPrice = originalPrice - discountAmount;
   }
 
-  private static void validate(BigDecimal originalPrice, BigDecimal discountAmount) {
+  private static void validate(Long originalPrice, Long discountAmount) {
     if (originalPrice == null || discountAmount == null) {
       throw new BadRequestException("originalPrice 또는 discountAmount는 null일 수 없습니다.");
     }
-    if (originalPrice.compareTo(BigDecimal.ZERO) < 0) {
+    if (originalPrice < 0) {
       throw new BadRequestException("originalPrice는 0 미만일 수 없습니다.");
     }
-    if (discountAmount.compareTo(BigDecimal.ZERO) < 0) {
+    if (discountAmount < 0) {
       throw new BadRequestException("discountAmount는 0 미만일 수 없습니다.");
     }
-    if (discountAmount.compareTo(originalPrice) > 0) {
+    if (discountAmount > 0) {
       throw new BadRequestException("discountAmount는 originalPrice를 초과할 수 없습니다.");
     }
   }

--- a/src/main/java/com/goggles/orderservice/domain/vo/OrderPrice.java
+++ b/src/main/java/com/goggles/orderservice/domain/vo/OrderPrice.java
@@ -40,7 +40,7 @@ public class OrderPrice {
     if (discountAmount < 0) {
       throw new BadRequestException("discountAmount는 0 미만일 수 없습니다.");
     }
-    if (discountAmount > 0) {
+    if (discountAmount.compareTo(originalPrice) > 0) {
       throw new BadRequestException("discountAmount는 originalPrice를 초과할 수 없습니다.");
     }
   }

--- a/src/main/java/com/goggles/orderservice/domain/vo/Product.java
+++ b/src/main/java/com/goggles/orderservice/domain/vo/Product.java
@@ -6,7 +6,6 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
-import java.math.BigDecimal;
 import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
@@ -25,14 +24,14 @@ public class Product {
   private String productName;
 
   @Column(name = "product_price", nullable = false)
-  private BigDecimal productPrice;
+  private Long productPrice;
 
   @Enumerated(EnumType.STRING)
   @Column(name = "product_type", nullable = false, length = 20)
   private OrderItemType productType;
 
   public Product(
-      UUID productId, String productName, BigDecimal productPrice, OrderItemType productType) {
+      UUID productId, String productName, Long productPrice, OrderItemType productType) {
     validate(productId, productName, productPrice, productType);
     this.productId = productId;
     this.productName = productName;
@@ -41,7 +40,7 @@ public class Product {
   }
 
   private static void validate(
-      UUID productId, String productName, BigDecimal productPrice, OrderItemType productType) {
+      UUID productId, String productName, Long productPrice, OrderItemType productType) {
     if (productId == null) {
       throw new BadRequestException("productId 값은 필수입니다.");
     }
@@ -51,7 +50,7 @@ public class Product {
     if (productPrice == null) {
       throw new BadRequestException("price 값은 필수입니다.");
     }
-    if (productPrice.compareTo(BigDecimal.ZERO) < 0) {
+    if (productPrice < 0) {
       throw new BadRequestException("productPrice 0 미만일 수 없습니다.");
     }
     if (productType == null) {

--- a/src/main/java/com/goggles/orderservice/domain/vo/Product.java
+++ b/src/main/java/com/goggles/orderservice/domain/vo/Product.java
@@ -30,8 +30,7 @@ public class Product {
   @Column(name = "product_type", nullable = false, length = 20)
   private OrderItemType productType;
 
-  public Product(
-      UUID productId, String productName, Long productPrice, OrderItemType productType) {
+  public Product(UUID productId, String productName, Long productPrice, OrderItemType productType) {
     validate(productId, productName, productPrice, productType);
     this.productId = productId;
     this.productName = productName;

--- a/src/main/java/com/goggles/orderservice/infrastructure/repository/OrderJpaRepository.java
+++ b/src/main/java/com/goggles/orderservice/infrastructure/repository/OrderJpaRepository.java
@@ -8,9 +8,10 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface OrderJpaRepository extends JpaRepository<Order, UUID> {
-  @Query("SELECT o FROM Order o " +
-      "LEFT JOIN FETCH o.items " +
-      "WHERE o.id = :orderId AND o.orderer.studentId = :studentId")
+  @Query(
+      "SELECT o FROM Order o "
+          + "LEFT JOIN FETCH o.items "
+          + "WHERE o.id = :orderId AND o.orderer.studentId = :studentId")
   Optional<Order> findByIdAndStudentId(
       @Param("orderId") UUID orderId, @Param("studentId") UUID studentId);
 }

--- a/src/main/java/com/goggles/orderservice/infrastructure/repository/OrderJpaRepository.java
+++ b/src/main/java/com/goggles/orderservice/infrastructure/repository/OrderJpaRepository.java
@@ -1,7 +1,16 @@
 package com.goggles.orderservice.infrastructure.repository;
 
 import com.goggles.orderservice.domain.entity.Order;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
-public interface OrderJpaRepository extends JpaRepository<Order, UUID> {}
+public interface OrderJpaRepository extends JpaRepository<Order, UUID> {
+  @Query("SELECT o FROM Order o " +
+      "LEFT JOIN FETCH o.items " +
+      "WHERE o.id = :orderId AND o.orderer.studentId = :studentId")
+  Optional<Order> findByIdAndStudentId(
+      @Param("orderId") UUID orderId, @Param("studentId") UUID studentId);
+}

--- a/src/main/java/com/goggles/orderservice/infrastructure/repository/OrderRepositoryImpl.java
+++ b/src/main/java/com/goggles/orderservice/infrastructure/repository/OrderRepositoryImpl.java
@@ -1,6 +1,9 @@
 package com.goggles.orderservice.infrastructure.repository;
 
+import com.goggles.orderservice.domain.entity.Order;
 import com.goggles.orderservice.domain.repository.OrderRepository;
+import java.util.Optional;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -8,4 +11,9 @@ import org.springframework.stereotype.Repository;
 @RequiredArgsConstructor
 public class OrderRepositoryImpl implements OrderRepository {
   private final OrderJpaRepository orderJpaRepository;
+
+  @Override
+  public Optional<Order> getOrderByIdAndUserId(UUID orderId, UUID userId) {
+    return orderJpaRepository.findByIdAndStudentId(orderId, userId);
+  }
 }

--- a/src/main/java/com/goggles/orderservice/presentation/controller/OrderController.java
+++ b/src/main/java/com/goggles/orderservice/presentation/controller/OrderController.java
@@ -29,8 +29,7 @@ public class OrderController {
 
   @GetMapping("/{orderId}")
   public OrderDetailResponse getOrderDetails(
-      @PathVariable("orderId") UUID orderId, @RequestHeader("X-User-Id") UUID userId
-  ) {
+      @PathVariable("orderId") UUID orderId, @RequestHeader("X-User-Id") UUID userId) {
     return OrderDetailResponse.from(orderQueryService.getOrderDetails(orderId, userId));
   }
 }

--- a/src/main/java/com/goggles/orderservice/presentation/controller/OrderController.java
+++ b/src/main/java/com/goggles/orderservice/presentation/controller/OrderController.java
@@ -1,0 +1,36 @@
+package com.goggles.orderservice.presentation.controller;
+
+import com.goggles.common.pagination.CommonPageRequest;
+import com.goggles.common.pagination.CommonPageResponse;
+import com.goggles.orderservice.application.service.OrderQueryService;
+import com.goggles.orderservice.presentation.dto.OrderDetailResponse;
+import com.goggles.orderservice.presentation.dto.OrderListResponse;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/orders")
+public class OrderController {
+
+  private final OrderQueryService orderQueryService;
+
+  @GetMapping
+  public CommonPageResponse<OrderListResponse> getOrders(
+      @RequestHeader("X-User-Id") UUID userId, @RequestBody CommonPageRequest request) {
+    return null;
+  }
+
+  @GetMapping("/{orderId}")
+  public OrderDetailResponse getOrderDetails(
+      @PathVariable("orderId") UUID orderId, @RequestHeader("X-User-Id") UUID userId
+  ) {
+    return OrderDetailResponse.from(orderQueryService.getOrderDetails(orderId, userId));
+  }
+}

--- a/src/main/java/com/goggles/orderservice/presentation/dto/OrderDetailResponse.java
+++ b/src/main/java/com/goggles/orderservice/presentation/dto/OrderDetailResponse.java
@@ -20,8 +20,7 @@ public record OrderDetailResponse(
     String paymentName,
     LocalDateTime orderDate,
     String orderStatus,
-    List<OrderItemSummaryResponse> orderItems
-) {
+    List<OrderItemSummaryResponse> orderItems) {
   public static OrderDetailResponse from(OrderDetailResult result) {
     return new OrderDetailResponse(
         result.orderId(),
@@ -37,9 +36,6 @@ public record OrderDetailResponse(
         result.payment() != null ? result.payment().getPaymentName() : null,
         result.createdAt(),
         result.status().name(),
-        result.orderItems().stream()
-            .map(OrderItemSummaryResponse::from)
-            .toList()
-    );
+        result.orderItems().stream().map(OrderItemSummaryResponse::from).toList());
   }
 }

--- a/src/main/java/com/goggles/orderservice/presentation/dto/OrderDetailResponse.java
+++ b/src/main/java/com/goggles/orderservice/presentation/dto/OrderDetailResponse.java
@@ -1,0 +1,45 @@
+package com.goggles.orderservice.presentation.dto;
+
+import com.goggles.orderservice.application.dto.result.OrderDetailResult;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+public record OrderDetailResponse(
+    UUID orderId,
+    UUID studentId,
+    String studentName,
+    Long originalPrice,
+    Long finalPrice,
+    UUID couponId,
+    String couponCode,
+    String couponName,
+    BigDecimal couponDiscountRate,
+    String paymentKey,
+    String paymentName,
+    LocalDateTime orderDate,
+    String orderStatus,
+    List<OrderItemSummaryResponse> orderItems
+) {
+  public static OrderDetailResponse from(OrderDetailResult result) {
+    return new OrderDetailResponse(
+        result.orderId(),
+        result.orderer().getStudentId(),
+        result.orderer().getStudentName(),
+        result.price().getOriginalPrice(),
+        result.price().getFinalPrice(),
+        result.coupon() != null ? result.coupon().getCouponId() : null,
+        result.coupon() != null ? result.coupon().getCouponCode() : null,
+        result.coupon() != null ? result.coupon().getCouponName() : null,
+        result.coupon() != null ? result.coupon().getCouponDiscountRate() : null,
+        result.payment() != null ? result.payment().getPaymentKey() : null,
+        result.payment() != null ? result.payment().getPaymentName() : null,
+        result.createdAt(),
+        result.status().name(),
+        result.orderItems().stream()
+            .map(OrderItemSummaryResponse::from)
+            .toList()
+    );
+  }
+}

--- a/src/main/java/com/goggles/orderservice/presentation/dto/OrderItemSummaryResponse.java
+++ b/src/main/java/com/goggles/orderservice/presentation/dto/OrderItemSummaryResponse.java
@@ -11,8 +11,7 @@ public record OrderItemSummaryResponse(
     String productType,
     UUID instructorId,
     String instructorName,
-    String orderItemStatus
-) {
+    String orderItemStatus) {
   public static OrderItemSummaryResponse from(OrderItemSummary item) {
     return new OrderItemSummaryResponse(
         item.orderItemId(),
@@ -22,7 +21,6 @@ public record OrderItemSummaryResponse(
         item.product().getProductType().name(),
         item.instructor().getInstructorId(),
         item.instructor().getInstructorName(),
-        item.status().name()
-    );
+        item.status().name());
   }
 }

--- a/src/main/java/com/goggles/orderservice/presentation/dto/OrderItemSummaryResponse.java
+++ b/src/main/java/com/goggles/orderservice/presentation/dto/OrderItemSummaryResponse.java
@@ -1,0 +1,28 @@
+package com.goggles.orderservice.presentation.dto;
+
+import com.goggles.orderservice.application.dto.result.OrderItemSummary;
+import java.util.UUID;
+
+public record OrderItemSummaryResponse(
+    UUID orderItemId,
+    UUID productId,
+    String productName,
+    Long productPrice,
+    String productType,
+    UUID instructorId,
+    String instructorName,
+    String orderItemStatus
+) {
+  public static OrderItemSummaryResponse from(OrderItemSummary item) {
+    return new OrderItemSummaryResponse(
+        item.orderItemId(),
+        item.product().getProductId(),
+        item.product().getProductName(),
+        item.product().getProductPrice(),
+        item.product().getProductType().name(),
+        item.instructor().getInstructorId(),
+        item.instructor().getInstructorName(),
+        item.status().name()
+    );
+  }
+}

--- a/src/main/java/com/goggles/orderservice/presentation/dto/OrderListResponse.java
+++ b/src/main/java/com/goggles/orderservice/presentation/dto/OrderListResponse.java
@@ -1,0 +1,25 @@
+package com.goggles.orderservice.presentation.dto;
+
+import com.goggles.orderservice.application.dto.result.OrderListResult;
+import com.goggles.orderservice.domain.enums.OrderStatus;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+public record OrderListResponse(
+    UUID orderId,
+    Long originalPrice,
+    Long finalPrice,
+    LocalDateTime createdAt,
+    OrderStatus status,
+    List<OrderItemSummaryResponse> orderItems) {
+  public static OrderListResponse from(OrderListResult result) {
+    return new OrderListResponse(
+        result.orderId(),
+        result.price().getOriginalPrice(),
+        result.price().getFinalPrice(),
+        result.createdAt(),
+        result.status(),
+        result.orderItems().stream().map(OrderItemSummaryResponse::from).toList());
+  }
+}

--- a/src/main/java/com/goggles/orderservice/presentation/dto/OrderListResponse.java
+++ b/src/main/java/com/goggles/orderservice/presentation/dto/OrderListResponse.java
@@ -11,7 +11,7 @@ public record OrderListResponse(
     Long originalPrice,
     Long finalPrice,
     LocalDateTime createdAt,
-    OrderStatus status,
+    String orderStatus,
     List<OrderItemSummaryResponse> orderItems) {
   public static OrderListResponse from(OrderListResult result) {
     return new OrderListResponse(
@@ -19,7 +19,7 @@ public record OrderListResponse(
         result.price().getOriginalPrice(),
         result.price().getFinalPrice(),
         result.createdAt(),
-        result.status(),
+        result.status().name(),
         result.orderItems().stream().map(OrderItemSummaryResponse::from).toList());
   }
 }

--- a/src/main/java/com/goggles/orderservice/presentation/dto/OrderListResponse.java
+++ b/src/main/java/com/goggles/orderservice/presentation/dto/OrderListResponse.java
@@ -1,7 +1,6 @@
 package com.goggles.orderservice.presentation.dto;
 
 import com.goggles.orderservice.application.dto.result.OrderListResult;
-import com.goggles.orderservice.domain.enums.OrderStatus;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;

--- a/src/test/java/com/goggles/orderservice/application/OrderQueryTest.java
+++ b/src/test/java/com/goggles/orderservice/application/OrderQueryTest.java
@@ -2,9 +2,9 @@ package com.goggles.orderservice.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.goggles.common.exception.NotFoundException;
 import com.goggles.orderservice.application.dto.command.CreateOrderItemCommand;
@@ -35,11 +35,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @Slf4j
 @ExtendWith(MockitoExtension.class)
 public class OrderQueryTest {
-  @InjectMocks
-  private OrderQueryServiceImpl orderQueryServiceImpl;
+  @InjectMocks private OrderQueryServiceImpl orderQueryServiceImpl;
 
-  @Mock
-  private OrderRepository orderRepository;
+  @Mock private OrderRepository orderRepository;
 
   private UUID orderId;
   private UUID userId;
@@ -49,19 +47,15 @@ public class OrderQueryTest {
   void setUp() {
     userId = UUID.randomUUID();
 
-    List<CreateOrderItemCommand> itemCommands = List.of(
-        new CreateOrderItemCommand(
-            new Product(UUID.randomUUID(), "자바 강의", 100000L, OrderItemType.COURSE),
-            new Instructor(UUID.randomUUID(), "강사명")
-        )
-    );
+    List<CreateOrderItemCommand> itemCommands =
+        List.of(
+            new CreateOrderItemCommand(
+                new Product(UUID.randomUUID(), "자바 강의", 100000L, OrderItemType.COURSE),
+                new Instructor(UUID.randomUUID(), "강사명")));
 
-    order = Order.create(
-        new Orderer(userId, "신혜원"),
-        null,
-        new OrderPrice(110000L, 15000L),
-        itemCommands
-    );
+    order =
+        Order.create(
+            new Orderer(userId, "신혜원"), null, new OrderPrice(110000L, 15000L), itemCommands);
 
     orderId = order.getId();
   }
@@ -73,8 +67,7 @@ public class OrderQueryTest {
     @DisplayName("성공: 주문 상세 조회(유저 아이디)")
     void getOrderDetails_success() {
       // given
-      when(orderRepository.getOrderByIdAndUserId(orderId, userId))
-          .thenReturn(Optional.of(order));
+      when(orderRepository.getOrderByIdAndUserId(orderId, userId)).thenReturn(Optional.of(order));
 
       // when
       OrderDetailResult result = orderQueryServiceImpl.getOrderDetails(orderId, userId);
@@ -97,8 +90,7 @@ public class OrderQueryTest {
     @DisplayName("실패: 주문을 찾을 수 없음")
     void getOrderDetails_notFound() {
       // given
-      when(orderRepository.getOrderByIdAndUserId(orderId, userId))
-          .thenReturn(Optional.empty());
+      when(orderRepository.getOrderByIdAndUserId(orderId, userId)).thenReturn(Optional.empty());
 
       // when & then
       assertThatThrownBy(() -> orderQueryServiceImpl.getOrderDetails(orderId, userId))

--- a/src/test/java/com/goggles/orderservice/application/OrderQueryTest.java
+++ b/src/test/java/com/goggles/orderservice/application/OrderQueryTest.java
@@ -55,7 +55,14 @@ public class OrderQueryTest {
 
     order =
         Order.create(
-            new Orderer(userId, "신혜원"), null, new OrderPrice(110000L, 15000L), itemCommands);
+            new Orderer(userId, "신혜원"),
+            null,
+            new OrderPrice(110000L, 15000L),
+            List.of(Order.createItem(
+                new Product(UUID.randomUUID(), "자바 강의", 100000L, OrderItemType.COURSE),
+                new Instructor(UUID.randomUUID(), "강사명"))
+            )
+        );
 
     orderId = order.getId();
   }

--- a/src/test/java/com/goggles/orderservice/application/OrderQueryTest.java
+++ b/src/test/java/com/goggles/orderservice/application/OrderQueryTest.java
@@ -1,0 +1,111 @@
+package com.goggles.orderservice.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.times;
+
+import com.goggles.common.exception.NotFoundException;
+import com.goggles.orderservice.application.dto.command.CreateOrderItemCommand;
+import com.goggles.orderservice.application.dto.result.OrderDetailResult;
+import com.goggles.orderservice.application.dto.result.OrderItemSummary;
+import com.goggles.orderservice.application.service.impl.OrderQueryServiceImpl;
+import com.goggles.orderservice.domain.entity.Order;
+import com.goggles.orderservice.domain.enums.OrderItemStatus;
+import com.goggles.orderservice.domain.enums.OrderItemType;
+import com.goggles.orderservice.domain.repository.OrderRepository;
+import com.goggles.orderservice.domain.vo.Instructor;
+import com.goggles.orderservice.domain.vo.OrderPrice;
+import com.goggles.orderservice.domain.vo.Orderer;
+import com.goggles.orderservice.domain.vo.Product;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@Slf4j
+@ExtendWith(MockitoExtension.class)
+public class OrderQueryTest {
+  @InjectMocks
+  private OrderQueryServiceImpl orderQueryServiceImpl;
+
+  @Mock
+  private OrderRepository orderRepository;
+
+  private UUID orderId;
+  private UUID userId;
+  private Order order;
+
+  @BeforeEach
+  void setUp() {
+    userId = UUID.randomUUID();
+
+    List<CreateOrderItemCommand> itemCommands = List.of(
+        new CreateOrderItemCommand(
+            new Product(UUID.randomUUID(), "자바 강의", 100000L, OrderItemType.COURSE),
+            new Instructor(UUID.randomUUID(), "강사명")
+        )
+    );
+
+    order = Order.create(
+        new Orderer(userId, "신혜원"),
+        null,
+        new OrderPrice(110000L, 15000L),
+        itemCommands
+    );
+
+    orderId = order.getId();
+  }
+
+  @Nested
+  @DisplayName("주문 상세 조회")
+  class GetOrderDetails {
+    @Test
+    @DisplayName("성공: 주문 상세 조회(유저 아이디)")
+    void getOrderDetails_success() {
+      // given
+      when(orderRepository.getOrderByIdAndUserId(orderId, userId))
+          .thenReturn(Optional.of(order));
+
+      // when
+      OrderDetailResult result = orderQueryServiceImpl.getOrderDetails(orderId, userId);
+
+      // then
+      assertThat(result).isNotNull();
+      assertThat(result.orderId()).isEqualTo(orderId);
+      assertThat(result.orderer().getStudentId()).isEqualTo(userId);
+      assertThat(result.orderItems()).hasSize(1);
+
+      OrderItemSummary item = result.orderItems().get(0);
+      assertThat(item.product().getProductName()).isEqualTo("자바 강의");
+      assertThat(item.instructor().getInstructorName()).isEqualTo("강사명");
+      assertThat(item.status()).isEqualTo(OrderItemStatus.ACTIVE);
+
+      verify(orderRepository, times(1)).getOrderByIdAndUserId(orderId, userId);
+    }
+
+    @Test
+    @DisplayName("실패: 주문을 찾을 수 없음")
+    void getOrderDetails_notFound() {
+      // given
+      when(orderRepository.getOrderByIdAndUserId(orderId, userId))
+          .thenReturn(Optional.empty());
+
+      // when & then
+      assertThatThrownBy(() -> orderQueryServiceImpl.getOrderDetails(orderId, userId))
+          .isInstanceOf(NotFoundException.class)
+          .hasMessage("주문을 찾을 수 없습니다.");
+
+      verify(orderRepository, times(1)).getOrderByIdAndUserId(orderId, userId);
+    }
+  }
+}

--- a/src/test/java/com/goggles/orderservice/application/OrderQueryTest.java
+++ b/src/test/java/com/goggles/orderservice/application/OrderQueryTest.java
@@ -58,11 +58,10 @@ public class OrderQueryTest {
             new Orderer(userId, "신혜원"),
             null,
             new OrderPrice(110000L, 15000L),
-            List.of(Order.createItem(
-                new Product(UUID.randomUUID(), "자바 강의", 100000L, OrderItemType.COURSE),
-                new Instructor(UUID.randomUUID(), "강사명"))
-            )
-        );
+            List.of(
+                Order.createItem(
+                    new Product(UUID.randomUUID(), "자바 강의", 100000L, OrderItemType.COURSE),
+                    new Instructor(UUID.randomUUID(), "강사명"))));
 
     orderId = order.getId();
   }

--- a/src/test/java/com/goggles/orderservice/application/OrderQueryTest.java
+++ b/src/test/java/com/goggles/orderservice/application/OrderQueryTest.java
@@ -7,7 +7,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.goggles.common.exception.NotFoundException;
-import com.goggles.orderservice.application.dto.command.CreateOrderItemCommand;
 import com.goggles.orderservice.application.dto.result.OrderDetailResult;
 import com.goggles.orderservice.application.dto.result.OrderItemSummary;
 import com.goggles.orderservice.application.service.impl.OrderQueryServiceImpl;
@@ -31,6 +30,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 @Slf4j
 @ExtendWith(MockitoExtension.class)
@@ -47,12 +47,6 @@ public class OrderQueryTest {
   void setUp() {
     userId = UUID.randomUUID();
 
-    List<CreateOrderItemCommand> itemCommands =
-        List.of(
-            new CreateOrderItemCommand(
-                new Product(UUID.randomUUID(), "자바 강의", 100000L, OrderItemType.COURSE),
-                new Instructor(UUID.randomUUID(), "강사명")));
-
     order =
         Order.create(
             new Orderer(userId, "신혜원"),
@@ -63,6 +57,7 @@ public class OrderQueryTest {
                     new Product(UUID.randomUUID(), "자바 강의", 100000L, OrderItemType.COURSE),
                     new Instructor(UUID.randomUUID(), "강사명"))));
 
+    ReflectionTestUtils.setField(order, "id", UUID.randomUUID());
     orderId = order.getId();
   }
 


### PR DESCRIPTION
### 📌 관련 이슈
- close #5 

### 💡 작업 내용
- 주문 상세 조회 Service, Controller 코드 추가
- Service 단위 테스트 코드 추가
- HTTP 테스트 코드 추가
- OrderItem이 Order 내부에서 생성되도록 주문 도메인 구조 수정

### 🔍 변경 이유
- 주문 단위의 상세 정보를 조회할 수 있는 기능을 제공하기 위함
- 비즈니스 로직의 정상 동작을 검증하기 위해 Service 단위 테스트를 추가하기 위함
- 실제 API 요청/응답 흐름을 검증하기 위해 HTTP 테스트를 추가하기 위함
- OrderItem이 Order의 생명주기를 따르도록 하여 도메인 응집도를 높이고 생성 책임을 명확히 하기 위함

### 📝 리뷰 포인트 (선택)
- 집중해서 봐줬으면 하는 부분

### 🧠 기타 참고 사항
(참고 문서, 스크린샷 등)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 주문 상세 조회 API 엔드포인트 추가

* **Tests**
  * 주문 조회 서비스 단위 테스트 추가

* **Chores**
  * 개발 환경 설정 파일 추가
  * 데이터베이스 초기화 스크립트 확장
  * 테스트 의존성 업데이트
<!-- end of auto-generated comment: release notes by coderabbit.ai -->