### PR TITLE
Feat/13 order resilience4j

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
 	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+	implementation 'org.springframework.cloud:spring-cloud-starter-circuitbreaker-resilience4j'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'org.postgresql:postgresql'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/http/http-client.env.json
+++ b/http/http-client.env.json
@@ -1,7 +1,7 @@
 {
   "local": {
     "host": "localhost:9007",
-    "userId": "550e8400-e29b-41d4-a716-446655440003",
-    "orderId": "6129d32b-ee8b-4871-8a2b-b684d1c1a913"
+    "userId": "550e8400-e29b-41d4-a716-446655440000",
+    "orderId": "95e903be-91b7-4c55-9910-c271c2e964b0"
   }
 }

--- a/http/init.sql
+++ b/http/init.sql
@@ -1,62 +1,178 @@
 DO $$
-    DECLARE
-        user_ids uuid[] := ARRAY[
-            '550e8400-e29b-41d4-a716-446655440000', '550e8400-e29b-41d4-a716-446655440001',
-            '550e8400-e29b-41d4-a716-446655440002', '550e8400-e29b-41d4-a716-446655440003',
-            '550e8400-e29b-41d4-a716-446655440004'
-            ];
-        user_names varchar[] := ARRAY['신혜원', '이호영', '김시온', '한소연', '하지혜'];
-        v_order_id uuid;
-        v_user_idx int;
-        v_item_count int;
-        v_total_price bigint;
-        v_discount bigint;
-        v_item_prices bigint[];
-        i int; j int;
-    BEGIN
-        FOR i IN 1..50 LOOP
-                v_order_id := gen_random_uuid();
-                v_user_idx := (floor(random() * 5) + 1)::int;
-                v_item_count := (floor(random() * 4) + 1)::int;
-                v_total_price := 0;
-                v_item_prices := '{}';
+DECLARE
+user_ids uuid[] := ARRAY[
+        '550e8400-e29b-41d4-a716-446655440000',
+        '550e8400-e29b-41d4-a716-446655440001',
+        '550e8400-e29b-41d4-a716-446655440002',
+        '550e8400-e29b-41d4-a716-446655440003',
+        '550e8400-e29b-41d4-a716-446655440004'
+    ];
 
-                FOR j IN 1..v_item_count LOOP
-                        DECLARE
-                            v_p bigint := (floor(random() * 10) + 1) * 10000;
-                        BEGIN
-                            v_item_prices := array_append(v_item_prices, v_p);
-                            v_total_price := v_total_price + v_p;
-                        END;
-                    END LOOP;
+    user_names varchar[] := ARRAY[
+        '신혜원', '이호영', '김시온', '한소연', '하지혜'
+    ];
 
-                v_discount := CASE WHEN random() > 0.5 THEN (v_total_price * 0.1)::bigint ELSE 0 END;
+    instructors varchar[] := ARRAY[
+        '김개발', '박강사', '이튜터', '최멘토', '정코치'
+    ];
 
-                INSERT INTO order_db.p_order (
-                    id, student_id, student_name, original_price, discount_amount, final_price,
-                    status, created_at, updated_at, created_by, updated_by,
-                    coupon_id, coupon_discount_rate, coupon_name, coupon_code
-                ) VALUES (
-                             v_order_id, user_ids[v_user_idx], user_names[v_user_idx], v_total_price, v_discount, v_total_price - v_discount,
-                             (ARRAY['PAYMENT_PENDING', 'PAID', 'COMPLETED', 'CANCELED'])[floor(random()*4)+1],
-                             now(), now(), user_ids[v_user_idx], user_ids[v_user_idx],
-                             CASE WHEN v_discount > 0 THEN gen_random_uuid() ELSE NULL END, -- coupon_id 추가
-                             CASE WHEN v_discount > 0 THEN 10.00 ELSE NULL END,             -- 0 대신 NULL 처리
-                             CASE WHEN v_discount > 0 THEN '신규 가입 감사 쿠폰' ELSE NULL END,
-                             CASE WHEN v_discount > 0 THEN 'WELCOME_2026' ELSE NULL END
-                         );
+    lecture_names varchar[] := ARRAY[
+        '스프링 부트 완전 정복',
+        '자바 백엔드 입문',
+        'JPA 실전 강의',
+        '알고리즘 마스터',
+        '면접 대비 특강'
+    ];
 
-                FOR j IN 1..v_item_count LOOP
-                        INSERT INTO order_db.p_order_item (
-                            id, order_id, product_id, instructor_id, instructor_name,
-                            product_name, product_price, product_type, status,
-                            created_at, updated_at, created_by, updated_by
-                        ) VALUES (
-                                     gen_random_uuid(), v_order_id, gen_random_uuid(), gen_random_uuid(), '강사_' || j,
-                                     '상품 ' || i || '-' || j, v_item_prices[j],
-                                     (ARRAY['COURSE', 'MENTORING'])[floor(random()*2)+1], 'ACTIVE',
-                                     now(), now(), user_ids[v_user_idx], user_ids[v_user_idx]
-                                 );
-                    END LOOP;
-            END LOOP;
-    END $$;
+    mentoring_names varchar[] := ARRAY[
+        '백엔드 취업 멘토링',
+        '이력서 첨삭',
+        '기술 면접 대비',
+        '커리어 상담',
+        '포트폴리오 리뷰'
+    ];
+
+    cancel_reasons varchar[] := ARRAY[
+        '단순 변심',
+        '가격 부담',
+        '다른 강의 선택',
+        '결제 오류',
+        '일정 변경'
+    ];
+
+    v_order_id uuid;
+    v_user_idx int;
+    v_item_count int;
+    v_total_price bigint;
+    v_discount bigint;
+    v_item_prices bigint[];
+    v_created_at timestamp;
+    v_status varchar;
+    v_canceled_at timestamp;
+    v_cancel_reason int;
+    v_cancel_desc varchar;
+
+    i int; j int;
+BEGIN
+FOR i IN 1..50 LOOP
+        v_order_id := gen_random_uuid();
+        v_user_idx := (floor(random() * 5) + 1)::int;
+        v_item_count := (floor(random() * 4) + 1)::int;
+        v_total_price := 0;
+        v_item_prices := '{}';
+
+        v_created_at := timestamp '2026-01-01'
+            + (random() * (timestamp '2026-04-30' - timestamp '2026-01-01'));
+
+FOR j IN 1..v_item_count LOOP
+            DECLARE
+v_p bigint := (floor(random() * 10) + 1) * 10000;
+BEGIN
+                v_item_prices := array_append(v_item_prices, v_p);
+                v_total_price := v_total_price + v_p;
+END;
+END LOOP;
+
+        v_discount := CASE
+            WHEN random() > 0.5 THEN (v_total_price * 0.1)::bigint
+            ELSE 0
+END;
+
+        v_status := (
+            ARRAY[
+                'PAYMENT_PENDING',
+                'PAID',
+                'COMPLETED',
+                'CANCELED',
+                'PAYMENT_FAILED'
+            ]
+        )[floor(random()*5)+1];
+
+        v_canceled_at := NULL;
+        v_cancel_reason := NULL;
+        v_cancel_desc := NULL;
+
+        IF v_status = 'CANCELED' THEN
+            v_canceled_at := v_created_at + interval '1 hour' * (floor(random()*48)+1);
+            v_cancel_reason := (floor(random()*5)+1)::int;
+            v_cancel_desc := cancel_reasons[v_cancel_reason];
+END IF;
+
+INSERT INTO order_db.p_order (
+    id, student_id, student_name,
+    original_price, discount_amount, final_price,
+    status, created_at, updated_at,
+    canceled_at, cancel_reason, cancel_description,
+    created_by, updated_by,
+    coupon_id, coupon_discount_rate, coupon_name, coupon_code,
+    payment_name, payment_key
+) VALUES (
+             v_order_id,
+             user_ids[v_user_idx],
+             user_names[v_user_idx],
+             v_total_price,
+             v_discount,
+             v_total_price - v_discount,
+             v_status,
+             v_created_at,
+             v_created_at,
+             v_canceled_at,
+             v_cancel_reason,
+             v_cancel_desc,
+             user_ids[v_user_idx],
+             user_ids[v_user_idx],
+             CASE WHEN v_discount > 0 THEN gen_random_uuid() ELSE NULL END,
+             CASE WHEN v_discount > 0 THEN 10.00 ELSE NULL END,
+             CASE WHEN v_discount > 0 THEN '신규 가입 쿠폰' ELSE NULL END,
+             CASE WHEN v_discount > 0 THEN 'WELCOME_2026' ELSE NULL END,
+             (ARRAY['카카오페이','토스페이','네이버페이','신용카드'])[floor(random()*4)+1],
+             CASE
+                 WHEN v_status = 'PAYMENT_FAILED' THEN NULL
+                 ELSE 'pay_' || floor(random()*100000)
+                 END
+         );
+
+-- 아이템 생성
+FOR j IN 1..v_item_count LOOP
+            DECLARE
+v_type varchar;
+                v_product_name varchar;
+BEGIN
+                v_type := (ARRAY['LECTURE', 'MENTORING'])[floor(random()*2)+1];
+
+                v_product_name :=
+                    CASE
+                        WHEN v_type = 'LECTURE'
+                            THEN lecture_names[(floor(random()*5)+1)::int]
+                        ELSE mentoring_names[(floor(random()*5)+1)::int]
+END;
+
+INSERT INTO order_db.p_order_item (
+    id, order_id, product_id,
+    instructor_id, instructor_name,
+    product_name, product_price,
+    product_type, status,
+    created_at, updated_at,
+    created_by, updated_by
+) VALUES (
+             gen_random_uuid(),
+             v_order_id,
+             gen_random_uuid(),
+             gen_random_uuid(),
+             instructors[(floor(random()*5)+1)::int],
+             v_product_name,
+             v_item_prices[j],
+             v_type,
+             CASE
+                 WHEN v_status IN ('CANCELED','PAYMENT_FAILED') THEN 'CANCELED'
+                 ELSE 'ACTIVE'
+                 END,
+             v_created_at,
+             v_created_at,
+             user_ids[v_user_idx],
+             user_ids[v_user_idx]
+         );
+END;
+END LOOP;
+END LOOP;
+END $$;

--- a/src/main/java/com/goggles/orderservice/application/common/CancelReason.java
+++ b/src/main/java/com/goggles/orderservice/application/common/CancelReason.java
@@ -1,0 +1,21 @@
+package com.goggles.orderservice.application.common;
+
+import com.goggles.common.exception.BadRequestException;
+
+public enum CancelReason {
+  PAYMENT_FAIL,
+  USER_CANCEL,
+  SYSTEM_ERROR,
+  MENTOR_CANCEL,
+  INSTRUCTOR_CANCEL,
+  TIMEOUT;
+
+  public static CancelReason from(String value) {
+    if (value == null || value.isBlank()) throw new BadRequestException("취소 원인은 필수입니다.");
+    try {
+      return CancelReason.valueOf(value.toUpperCase());
+    } catch (IllegalArgumentException e) {
+      throw new BadRequestException("유효하지 취소 원인입니다: " + value);
+    }
+  }
+}

--- a/src/main/java/com/goggles/orderservice/application/dto/command/CreateLectureOrderCommand.java
+++ b/src/main/java/com/goggles/orderservice/application/dto/command/CreateLectureOrderCommand.java
@@ -1,7 +1,8 @@
 package com.goggles.orderservice.application.dto.command;
 
+import com.goggles.orderservice.application.common.UserRole;
 import java.util.List;
 import java.util.UUID;
 
 public record CreateLectureOrderCommand(
-    UUID userId, String userRole, UUID couponId, String paymentMethod, List<UUID> items) {}
+    UUID userId, UserRole userRole, UUID couponId, String paymentMethod, List<UUID> items) {}

--- a/src/main/java/com/goggles/orderservice/application/dto/command/CreateMentoringOrderCommand.java
+++ b/src/main/java/com/goggles/orderservice/application/dto/command/CreateMentoringOrderCommand.java
@@ -1,5 +1,6 @@
 package com.goggles.orderservice.application.dto.command;
 
+import com.goggles.orderservice.application.common.UserRole;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
@@ -7,7 +8,7 @@ import java.util.UUID;
 
 public record CreateMentoringOrderCommand(
     UUID userId,
-    String userRole,
+    UserRole userRole,
     UUID mentoringId,
     String requestMessage,
     UUID couponId,

--- a/src/main/java/com/goggles/orderservice/application/dto/external/CancelLectureEnrollmentData.java
+++ b/src/main/java/com/goggles/orderservice/application/dto/external/CancelLectureEnrollmentData.java
@@ -5,9 +5,9 @@ import java.util.List;
 import java.util.UUID;
 
 public record CancelLectureEnrollmentData(
-    UUID userId, List<UUID> LectureEnrollmentIds, CancelReason cancelReason) {
+    UUID userId, String userRole, List<UUID> LectureEnrollmentIds, CancelReason cancelReason) {
   public static CancelLectureEnrollmentData of(
-      UUID userId, List<UUID> LectureEnrollmentIds, CancelReason cancelReason) {
-    return new CancelLectureEnrollmentData(userId, LectureEnrollmentIds, cancelReason);
+      UUID userId, String userRole, List<UUID> LectureEnrollmentIds, CancelReason cancelReason) {
+    return new CancelLectureEnrollmentData(userId, userRole, LectureEnrollmentIds, cancelReason);
   }
 }

--- a/src/main/java/com/goggles/orderservice/application/dto/external/CancelLectureEnrollmentData.java
+++ b/src/main/java/com/goggles/orderservice/application/dto/external/CancelLectureEnrollmentData.java
@@ -4,16 +4,10 @@ import com.goggles.orderservice.application.common.CancelReason;
 import java.util.List;
 import java.util.UUID;
 
-public record CancelLectureEnrollmentData (
-    UUID userId,
-    List<UUID> mentoringBookingIds,
-    CancelReason cancelReason
-) {
-  public static CancelLectureEnrollmentData of(UUID userId, List<UUID> mentoringBookingIds, CancelReason cancelReason) {
-    return new CancelLectureEnrollmentData(
-        userId,
-        mentoringBookingIds,
-        cancelReason
-    );
+public record CancelLectureEnrollmentData(
+    UUID userId, List<UUID> mentoringBookingIds, CancelReason cancelReason) {
+  public static CancelLectureEnrollmentData of(
+      UUID userId, List<UUID> mentoringBookingIds, CancelReason cancelReason) {
+    return new CancelLectureEnrollmentData(userId, mentoringBookingIds, cancelReason);
   }
 }

--- a/src/main/java/com/goggles/orderservice/application/dto/external/CancelLectureEnrollmentData.java
+++ b/src/main/java/com/goggles/orderservice/application/dto/external/CancelLectureEnrollmentData.java
@@ -1,13 +1,14 @@
 package com.goggles.orderservice.application.dto.external;
 
+import com.goggles.orderservice.application.common.UserRole;
 import com.goggles.orderservice.domain.model.CancelReason;
 import java.util.List;
 import java.util.UUID;
 
 public record CancelLectureEnrollmentData(
-    UUID userId, String userRole, List<UUID> LectureEnrollmentIds, CancelReason cancelReason) {
+    UUID userId, UserRole userRole, List<UUID> LectureEnrollmentIds, CancelReason cancelReason) {
   public static CancelLectureEnrollmentData of(
-      UUID userId, String userRole, List<UUID> LectureEnrollmentIds, CancelReason cancelReason) {
+      UUID userId, UserRole userRole, List<UUID> LectureEnrollmentIds, CancelReason cancelReason) {
     return new CancelLectureEnrollmentData(userId, userRole, LectureEnrollmentIds, cancelReason);
   }
 }

--- a/src/main/java/com/goggles/orderservice/application/dto/external/CancelLectureEnrollmentData.java
+++ b/src/main/java/com/goggles/orderservice/application/dto/external/CancelLectureEnrollmentData.java
@@ -1,0 +1,19 @@
+package com.goggles.orderservice.application.dto.external;
+
+import com.goggles.orderservice.application.common.CancelReason;
+import java.util.List;
+import java.util.UUID;
+
+public record CancelLectureEnrollmentData (
+    UUID userId,
+    List<UUID> mentoringBookingIds,
+    CancelReason cancelReason
+) {
+  public static CancelLectureEnrollmentData of(UUID userId, List<UUID> mentoringBookingIds, CancelReason cancelReason) {
+    return new CancelLectureEnrollmentData(
+        userId,
+        mentoringBookingIds,
+        cancelReason
+    );
+  }
+}

--- a/src/main/java/com/goggles/orderservice/application/dto/external/CancelLectureEnrollmentData.java
+++ b/src/main/java/com/goggles/orderservice/application/dto/external/CancelLectureEnrollmentData.java
@@ -1,13 +1,13 @@
 package com.goggles.orderservice.application.dto.external;
 
-import com.goggles.orderservice.application.common.CancelReason;
+import com.goggles.orderservice.domain.model.CancelReason;
 import java.util.List;
 import java.util.UUID;
 
 public record CancelLectureEnrollmentData(
-    UUID userId, List<UUID> mentoringBookingIds, CancelReason cancelReason) {
+    UUID userId, List<UUID> LectureEnrollmentIds, CancelReason cancelReason) {
   public static CancelLectureEnrollmentData of(
-      UUID userId, List<UUID> mentoringBookingIds, CancelReason cancelReason) {
-    return new CancelLectureEnrollmentData(userId, mentoringBookingIds, cancelReason);
+      UUID userId, List<UUID> LectureEnrollmentIds, CancelReason cancelReason) {
+    return new CancelLectureEnrollmentData(userId, LectureEnrollmentIds, cancelReason);
   }
 }

--- a/src/main/java/com/goggles/orderservice/application/dto/external/CancelMentoringBookingData.java
+++ b/src/main/java/com/goggles/orderservice/application/dto/external/CancelMentoringBookingData.java
@@ -1,6 +1,6 @@
 package com.goggles.orderservice.application.dto.external;
 
-import com.goggles.orderservice.application.common.CancelReason;
+import com.goggles.orderservice.domain.model.CancelReason;
 import java.util.UUID;
 
 public record CancelMentoringBookingData(

--- a/src/main/java/com/goggles/orderservice/application/dto/external/CancelMentoringBookingData.java
+++ b/src/main/java/com/goggles/orderservice/application/dto/external/CancelMentoringBookingData.java
@@ -1,12 +1,13 @@
 package com.goggles.orderservice.application.dto.external;
 
+import com.goggles.orderservice.application.common.UserRole;
 import com.goggles.orderservice.domain.model.CancelReason;
 import java.util.UUID;
 
 public record CancelMentoringBookingData(
-    UUID userId, UUID mentoringBookingId, CancelReason cancelReason) {
+    UUID userId, UserRole userRole, UUID mentoringBookingId, CancelReason cancelReason) {
   public static CancelMentoringBookingData of(
-      UUID userId, UUID mentoringBookingId, CancelReason cancelReason) {
-    return new CancelMentoringBookingData(userId, mentoringBookingId, cancelReason);
+      UUID userId, UserRole userRole, UUID mentoringBookingId, CancelReason cancelReason) {
+    return new CancelMentoringBookingData(userId, userRole, mentoringBookingId, cancelReason);
   }
 }

--- a/src/main/java/com/goggles/orderservice/application/dto/external/CancelMentoringBookingData.java
+++ b/src/main/java/com/goggles/orderservice/application/dto/external/CancelMentoringBookingData.java
@@ -4,15 +4,9 @@ import com.goggles.orderservice.application.common.CancelReason;
 import java.util.UUID;
 
 public record CancelMentoringBookingData(
-    UUID userId,
-    UUID mentoringBookingId,
-    CancelReason cancelReason
-) {
-  public static CancelMentoringBookingData of(UUID userId, UUID mentoringBookingId, CancelReason cancelReason) {
-    return new CancelMentoringBookingData(
-        userId,
-        mentoringBookingId,
-        cancelReason
-    );
+    UUID userId, UUID mentoringBookingId, CancelReason cancelReason) {
+  public static CancelMentoringBookingData of(
+      UUID userId, UUID mentoringBookingId, CancelReason cancelReason) {
+    return new CancelMentoringBookingData(userId, mentoringBookingId, cancelReason);
   }
 }

--- a/src/main/java/com/goggles/orderservice/application/dto/external/CancelMentoringBookingData.java
+++ b/src/main/java/com/goggles/orderservice/application/dto/external/CancelMentoringBookingData.java
@@ -1,0 +1,18 @@
+package com.goggles.orderservice.application.dto.external;
+
+import com.goggles.orderservice.application.common.CancelReason;
+import java.util.UUID;
+
+public record CancelMentoringBookingData(
+    UUID userId,
+    UUID mentoringBookingId,
+    CancelReason cancelReason
+) {
+  public static CancelMentoringBookingData of(UUID userId, UUID mentoringBookingId, String cancelReason) {
+    return new CancelMentoringBookingData(
+        userId,
+        mentoringBookingId,
+        CancelReason.from(cancelReason)
+    );
+  }
+}

--- a/src/main/java/com/goggles/orderservice/application/dto/external/CancelMentoringBookingData.java
+++ b/src/main/java/com/goggles/orderservice/application/dto/external/CancelMentoringBookingData.java
@@ -8,11 +8,11 @@ public record CancelMentoringBookingData(
     UUID mentoringBookingId,
     CancelReason cancelReason
 ) {
-  public static CancelMentoringBookingData of(UUID userId, UUID mentoringBookingId, String cancelReason) {
+  public static CancelMentoringBookingData of(UUID userId, UUID mentoringBookingId, CancelReason cancelReason) {
     return new CancelMentoringBookingData(
         userId,
         mentoringBookingId,
-        CancelReason.from(cancelReason)
+        cancelReason
     );
   }
 }

--- a/src/main/java/com/goggles/orderservice/application/dto/external/LectureProductReserveData.java
+++ b/src/main/java/com/goggles/orderservice/application/dto/external/LectureProductReserveData.java
@@ -9,6 +9,6 @@ public record LectureProductReserveData(
     List<UUID> productIds, UUID userId, UserRole userRole, String userName) {
   public static LectureProductReserveData of(CreateLectureOrderCommand command, String userName) {
     return new LectureProductReserveData(
-        command.items(), command.userId(), UserRole.from(command.userRole()), userName);
+        command.items(), command.userId(), command.userRole(), userName);
   }
 }

--- a/src/main/java/com/goggles/orderservice/application/dto/external/MentoringProductReserveData.java
+++ b/src/main/java/com/goggles/orderservice/application/dto/external/MentoringProductReserveData.java
@@ -25,7 +25,7 @@ public record MentoringProductReserveData(
       CreateMentoringOrderCommand command, String userName) {
     return new MentoringProductReserveData(
         command.userId(),
-        UserRole.from(command.userRole()),
+        command.userRole(),
         userName,
         command.mentoringId(),
         command.requestMessage(),

--- a/src/main/java/com/goggles/orderservice/application/dto/result/OrderDetailResult.java
+++ b/src/main/java/com/goggles/orderservice/application/dto/result/OrderDetailResult.java
@@ -1,6 +1,6 @@
 package com.goggles.orderservice.application.dto.result;
 
-import com.goggles.orderservice.application.common.CancelReason;
+import com.goggles.orderservice.domain.model.CancelReason;
 import com.goggles.orderservice.domain.model.Coupon;
 import com.goggles.orderservice.domain.model.Order;
 import com.goggles.orderservice.domain.model.OrderPrice;

--- a/src/main/java/com/goggles/orderservice/application/dto/result/OrderDetailResult.java
+++ b/src/main/java/com/goggles/orderservice/application/dto/result/OrderDetailResult.java
@@ -1,5 +1,6 @@
 package com.goggles.orderservice.application.dto.result;
 
+import com.goggles.orderservice.application.common.CancelReason;
 import com.goggles.orderservice.domain.model.Coupon;
 import com.goggles.orderservice.domain.model.Order;
 import com.goggles.orderservice.domain.model.OrderPrice;
@@ -18,6 +19,9 @@ public record OrderDetailResult(
     Payment payment,
     LocalDateTime createdAt,
     OrderStatus status,
+    CancelReason cancelReason,
+    String cancelDescription,
+    LocalDateTime canceledAt,
     List<OrderItemSummary> orderItems) {
   public static OrderDetailResult from(Order order) {
     return new OrderDetailResult(
@@ -28,6 +32,9 @@ public record OrderDetailResult(
         order.getPayment(),
         order.getCreatedAt(),
         order.getStatus(),
+        order.getCancelReason(),
+        order.getCancelDescription(),
+        order.getCanceledAt(),
         order.getItems().stream().map(OrderItemSummary::from).toList());
   }
 }

--- a/src/main/java/com/goggles/orderservice/application/port/out/LectureProvider.java
+++ b/src/main/java/com/goggles/orderservice/application/port/out/LectureProvider.java
@@ -3,10 +3,10 @@ package com.goggles.orderservice.application.port.out;
 import com.goggles.orderservice.application.dto.external.CancelLectureEnrollmentData;
 import com.goggles.orderservice.application.dto.external.LectureProductReserveData;
 import com.goggles.orderservice.application.dto.external.ProductReserveInfo;
-import com.goggles.orderservice.infrastructure.client.dto.CancelLectureEnrollmentRequest;
 import java.util.List;
 
 public interface LectureProvider {
   List<ProductReserveInfo> reserveEnrollment(LectureProductReserveData data);
+
   void cancelLectureEnrollment(CancelLectureEnrollmentData data);
 }

--- a/src/main/java/com/goggles/orderservice/application/port/out/LectureProvider.java
+++ b/src/main/java/com/goggles/orderservice/application/port/out/LectureProvider.java
@@ -1,9 +1,12 @@
 package com.goggles.orderservice.application.port.out;
 
+import com.goggles.orderservice.application.dto.external.CancelLectureEnrollmentData;
 import com.goggles.orderservice.application.dto.external.LectureProductReserveData;
 import com.goggles.orderservice.application.dto.external.ProductReserveInfo;
+import com.goggles.orderservice.infrastructure.client.dto.CancelLectureEnrollmentRequest;
 import java.util.List;
 
 public interface LectureProvider {
   List<ProductReserveInfo> reserveEnrollment(LectureProductReserveData data);
+  void cancelLectureEnrollment(CancelLectureEnrollmentData data);
 }

--- a/src/main/java/com/goggles/orderservice/application/port/out/MentoringProvider.java
+++ b/src/main/java/com/goggles/orderservice/application/port/out/MentoringProvider.java
@@ -6,5 +6,6 @@ import com.goggles.orderservice.application.dto.external.ProductReserveInfo;
 
 public interface MentoringProvider {
   ProductReserveInfo reserveEnrollment(MentoringProductReserveData data);
+
   void cancelMentoringBooking(CancelMentoringBookingData data);
 }

--- a/src/main/java/com/goggles/orderservice/application/port/out/MentoringProvider.java
+++ b/src/main/java/com/goggles/orderservice/application/port/out/MentoringProvider.java
@@ -1,8 +1,10 @@
 package com.goggles.orderservice.application.port.out;
 
+import com.goggles.orderservice.application.dto.external.CancelMentoringBookingData;
 import com.goggles.orderservice.application.dto.external.MentoringProductReserveData;
 import com.goggles.orderservice.application.dto.external.ProductReserveInfo;
 
 public interface MentoringProvider {
   ProductReserveInfo reserveEnrollment(MentoringProductReserveData data);
+  void cancelMentoringBooking(CancelMentoringBookingData data);
 }

--- a/src/main/java/com/goggles/orderservice/application/service/impl/OrderCommandServiceImpl.java
+++ b/src/main/java/com/goggles/orderservice/application/service/impl/OrderCommandServiceImpl.java
@@ -118,11 +118,13 @@ public class OrderCommandServiceImpl implements OrderCommandService {
     return productInfo.stream().map(product -> product.toOrderItemSpec(type)).toList();
   }
 
-  private void compensateLectureReservation(List<ProductReserveInfo> productInfo, UUID userId, String userRole) {
+  private void compensateLectureReservation(
+      List<ProductReserveInfo> productInfo, UUID userId, String userRole) {
     List<UUID> enrollmentIds = productInfo.stream().map(ProductReserveInfo::enrollmentId).toList();
     try {
       lectureProvider.cancelLectureEnrollment(
-          CancelLectureEnrollmentData.of(userId, userRole, enrollmentIds, CancelReason.SYSTEM_ERROR));
+          CancelLectureEnrollmentData.of(
+              userId, userRole, enrollmentIds, CancelReason.SYSTEM_ERROR));
     } catch (Exception e) {
       log.error("강의 예약 보상 트랜잭션 실패. enrollmentIds: {}", enrollmentIds);
       // todo: DLQ 적용

--- a/src/main/java/com/goggles/orderservice/application/service/impl/OrderCommandServiceImpl.java
+++ b/src/main/java/com/goggles/orderservice/application/service/impl/OrderCommandServiceImpl.java
@@ -1,7 +1,10 @@
 package com.goggles.orderservice.application.service.impl;
 
+import com.goggles.orderservice.application.common.CancelReason;
 import com.goggles.orderservice.application.dto.command.CreateLectureOrderCommand;
 import com.goggles.orderservice.application.dto.command.CreateMentoringOrderCommand;
+import com.goggles.orderservice.application.dto.external.CancelLectureEnrollmentData;
+import com.goggles.orderservice.application.dto.external.CancelMentoringBookingData;
 import com.goggles.orderservice.application.dto.external.LectureProductReserveData;
 import com.goggles.orderservice.application.dto.external.MentoringProductReserveData;
 import com.goggles.orderservice.application.dto.external.ProductReserveInfo;
@@ -20,11 +23,14 @@ import com.goggles.orderservice.domain.repository.OrderRepository;
 import jakarta.transaction.Transactional;
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class OrderCommandServiceImpl implements OrderCommandService {
   private final LectureProvider lectureProvider;
   private final MentoringProvider mentoringProvider;
@@ -39,16 +45,22 @@ public class OrderCommandServiceImpl implements OrderCommandService {
     Long totalPrice = calculateTotalPriceFromList(productInfo);
     List<OrderItemSpec> itemSpecs = convertOrderItemSpecs(productInfo, OrderItemType.LECTURE);
 
-    Order order =
-        Order.create(
-            new Orderer(userInfo.userId(), userInfo.userName()),
-            null,
-            new OrderPrice(totalPrice, 0L),
-            itemSpecs);
+    try {
+      Order order =
+          Order.create(
+              new Orderer(userInfo.userId(), userInfo.userName()),
+              null,
+              new OrderPrice(totalPrice, 0L),
+              itemSpecs);
 
-    order = orderRepository.createOrder(order);
-
-    return CreateOrderResult.from(order);
+      order = orderRepository.createOrder(order);
+      return CreateOrderResult.from(order);
+    } catch (Exception e) {
+      log.error("[강의 생성 실패] userId: {}, lectureIds: {}, cause: {}",
+          userInfo.userId(), productInfo.stream().map(ProductReserveInfo::productId).toList(), e.getMessage(), e);
+      compensateLectureReservation(productInfo, userInfo.userId());
+      throw e;
+    }
   }
 
   @Override
@@ -58,16 +70,21 @@ public class OrderCommandServiceImpl implements OrderCommandService {
     ProductReserveInfo productInfo = reserveMentoring(command, userInfo.userName());
     OrderItemSpec itemSpec = productInfo.toOrderItemSpec(OrderItemType.MENTORING);
 
-    Order order =
-        Order.create(
-            new Orderer(userInfo.userId(), userInfo.userName()),
-            null,
-            new OrderPrice(productInfo.productPrice(), 0L),
-            itemSpec);
+    try {
+      Order order = Order.create(
+          new Orderer(userInfo.userId(), userInfo.userName()),
+          null,
+          new OrderPrice(productInfo.productPrice(), 0L),
+          itemSpec);
 
-    order = orderRepository.createOrder(order);
-
-    return CreateOrderResult.from(order);
+      order = orderRepository.createOrder(order);
+      return CreateOrderResult.from(order);
+    } catch (Exception e) {
+      log.error("[멘토링 주문 생성 실패] userId: {}, mentoringId: {}, cause: {}",
+          userInfo.userId(), productInfo.enrollmentId(), e.getMessage(), e);
+      compensateMentoringReservation(productInfo, userInfo.userId());
+      throw e;
+    }
   }
 
   private UserInfo getUserInfo(UUID userId) {
@@ -91,5 +108,26 @@ public class OrderCommandServiceImpl implements OrderCommandService {
   private List<OrderItemSpec> convertOrderItemSpecs(
       List<ProductReserveInfo> productInfo, OrderItemType type) {
     return productInfo.stream().map(product -> product.toOrderItemSpec(type)).toList();
+  }
+
+  private void compensateLectureReservation(List<ProductReserveInfo> productInfo, UUID userId) {
+    List<UUID> productIds = productInfo.stream().map(ProductReserveInfo::productId).toList();
+    try {
+      lectureProvider.cancelLectureEnrollment(
+          CancelLectureEnrollmentData.of(userId, productIds, CancelReason.SYSTEM_ERROR));
+    } catch (Exception e) {
+      log.error("강의 예약 보상 트랜잭션 실패. enrollmentId: {}", productIds);
+      // todo: DLQ 적용
+    }
+  }
+
+  private void compensateMentoringReservation(ProductReserveInfo productInfo, UUID userId) {
+    try {
+      mentoringProvider.cancelMentoringBooking(
+          CancelMentoringBookingData.of(userId, productInfo.enrollmentId(), CancelReason.SYSTEM_ERROR));
+    } catch (Exception e) {
+      log.error("멘토링 예약 보상 트랜잭션 실패. enrollmentId: {}", productInfo.enrollmentId());
+      // todo: DLQ 적용
+    }
   }
 }

--- a/src/main/java/com/goggles/orderservice/application/service/impl/OrderCommandServiceImpl.java
+++ b/src/main/java/com/goggles/orderservice/application/service/impl/OrderCommandServiceImpl.java
@@ -1,5 +1,6 @@
 package com.goggles.orderservice.application.service.impl;
 
+import com.goggles.orderservice.application.common.UserRole;
 import com.goggles.orderservice.application.dto.command.CreateLectureOrderCommand;
 import com.goggles.orderservice.application.dto.command.CreateMentoringOrderCommand;
 import com.goggles.orderservice.application.dto.external.CancelLectureEnrollmentData;
@@ -90,7 +91,7 @@ public class OrderCommandServiceImpl implements OrderCommandService {
           productInfo.enrollmentId(),
           e.getMessage(),
           e);
-      compensateMentoringReservation(productInfo, userInfo.userId());
+      compensateMentoringReservation(productInfo, userInfo.userId(), command.userRole());
       throw e;
     }
   }
@@ -119,7 +120,7 @@ public class OrderCommandServiceImpl implements OrderCommandService {
   }
 
   private void compensateLectureReservation(
-      List<ProductReserveInfo> productInfo, UUID userId, String userRole) {
+      List<ProductReserveInfo> productInfo, UUID userId, UserRole userRole) {
     List<UUID> enrollmentIds = productInfo.stream().map(ProductReserveInfo::enrollmentId).toList();
     try {
       lectureProvider.cancelLectureEnrollment(
@@ -131,11 +132,12 @@ public class OrderCommandServiceImpl implements OrderCommandService {
     }
   }
 
-  private void compensateMentoringReservation(ProductReserveInfo productInfo, UUID userId) {
+  private void compensateMentoringReservation(
+      ProductReserveInfo productInfo, UUID userId, UserRole userRole) {
     try {
       mentoringProvider.cancelMentoringBooking(
           CancelMentoringBookingData.of(
-              userId, productInfo.enrollmentId(), CancelReason.SYSTEM_ERROR));
+              userId, userRole, productInfo.enrollmentId(), CancelReason.SYSTEM_ERROR));
     } catch (Exception e) {
       log.error("멘토링 예약 보상 트랜잭션 실패. enrollmentId: {}", productInfo.enrollmentId());
       // todo: DLQ 적용

--- a/src/main/java/com/goggles/orderservice/application/service/impl/OrderCommandServiceImpl.java
+++ b/src/main/java/com/goggles/orderservice/application/service/impl/OrderCommandServiceImpl.java
@@ -1,6 +1,5 @@
 package com.goggles.orderservice.application.service.impl;
 
-import com.goggles.orderservice.domain.model.CancelReason;
 import com.goggles.orderservice.application.dto.command.CreateLectureOrderCommand;
 import com.goggles.orderservice.application.dto.command.CreateMentoringOrderCommand;
 import com.goggles.orderservice.application.dto.external.CancelLectureEnrollmentData;
@@ -14,6 +13,7 @@ import com.goggles.orderservice.application.port.out.LectureProvider;
 import com.goggles.orderservice.application.port.out.MentoringProvider;
 import com.goggles.orderservice.application.port.out.UserReader;
 import com.goggles.orderservice.application.service.OrderCommandService;
+import com.goggles.orderservice.domain.model.CancelReason;
 import com.goggles.orderservice.domain.model.Order;
 import com.goggles.orderservice.domain.model.OrderItemSpec;
 import com.goggles.orderservice.domain.model.OrderItemType;

--- a/src/main/java/com/goggles/orderservice/application/service/impl/OrderCommandServiceImpl.java
+++ b/src/main/java/com/goggles/orderservice/application/service/impl/OrderCommandServiceImpl.java
@@ -118,7 +118,8 @@ public class OrderCommandServiceImpl implements OrderCommandService {
     return productInfo.stream().map(product -> product.toOrderItemSpec(type)).toList();
   }
 
-  private void compensateLectureReservation(List<ProductReserveInfo> productInfo, UUID userId, String userRole) {
+  private void compensateLectureReservation(
+      List<ProductReserveInfo> productInfo, UUID userId, String userRole) {
     List<UUID> productIds = productInfo.stream().map(ProductReserveInfo::productId).toList();
     try {
       lectureProvider.cancelLectureEnrollment(

--- a/src/main/java/com/goggles/orderservice/application/service/impl/OrderCommandServiceImpl.java
+++ b/src/main/java/com/goggles/orderservice/application/service/impl/OrderCommandServiceImpl.java
@@ -1,6 +1,6 @@
 package com.goggles.orderservice.application.service.impl;
 
-import com.goggles.orderservice.application.common.CancelReason;
+import com.goggles.orderservice.domain.model.CancelReason;
 import com.goggles.orderservice.application.dto.command.CreateLectureOrderCommand;
 import com.goggles.orderservice.application.dto.command.CreateMentoringOrderCommand;
 import com.goggles.orderservice.application.dto.external.CancelLectureEnrollmentData;

--- a/src/main/java/com/goggles/orderservice/application/service/impl/OrderCommandServiceImpl.java
+++ b/src/main/java/com/goggles/orderservice/application/service/impl/OrderCommandServiceImpl.java
@@ -118,14 +118,13 @@ public class OrderCommandServiceImpl implements OrderCommandService {
     return productInfo.stream().map(product -> product.toOrderItemSpec(type)).toList();
   }
 
-  private void compensateLectureReservation(
-      List<ProductReserveInfo> productInfo, UUID userId, String userRole) {
-    List<UUID> productIds = productInfo.stream().map(ProductReserveInfo::productId).toList();
+  private void compensateLectureReservation(List<ProductReserveInfo> productInfo, UUID userId, String userRole) {
+    List<UUID> enrollmentIds = productInfo.stream().map(ProductReserveInfo::enrollmentId).toList();
     try {
       lectureProvider.cancelLectureEnrollment(
-          CancelLectureEnrollmentData.of(userId, userRole, productIds, CancelReason.SYSTEM_ERROR));
+          CancelLectureEnrollmentData.of(userId, userRole, enrollmentIds, CancelReason.SYSTEM_ERROR));
     } catch (Exception e) {
-      log.error("강의 예약 보상 트랜잭션 실패. enrollmentId: {}", productIds);
+      log.error("강의 예약 보상 트랜잭션 실패. enrollmentIds: {}", enrollmentIds);
       // todo: DLQ 적용
     }
   }

--- a/src/main/java/com/goggles/orderservice/application/service/impl/OrderCommandServiceImpl.java
+++ b/src/main/java/com/goggles/orderservice/application/service/impl/OrderCommandServiceImpl.java
@@ -61,7 +61,7 @@ public class OrderCommandServiceImpl implements OrderCommandService {
           productInfo.stream().map(ProductReserveInfo::productId).toList(),
           e.getMessage(),
           e);
-      compensateLectureReservation(productInfo, userInfo.userId());
+      compensateLectureReservation(productInfo, userInfo.userId(), command.userRole());
       throw e;
     }
   }
@@ -118,11 +118,11 @@ public class OrderCommandServiceImpl implements OrderCommandService {
     return productInfo.stream().map(product -> product.toOrderItemSpec(type)).toList();
   }
 
-  private void compensateLectureReservation(List<ProductReserveInfo> productInfo, UUID userId) {
+  private void compensateLectureReservation(List<ProductReserveInfo> productInfo, UUID userId, String userRole) {
     List<UUID> productIds = productInfo.stream().map(ProductReserveInfo::productId).toList();
     try {
       lectureProvider.cancelLectureEnrollment(
-          CancelLectureEnrollmentData.of(userId, productIds, CancelReason.SYSTEM_ERROR));
+          CancelLectureEnrollmentData.of(userId, userRole, productIds, CancelReason.SYSTEM_ERROR));
     } catch (Exception e) {
       log.error("강의 예약 보상 트랜잭션 실패. enrollmentId: {}", productIds);
       // todo: DLQ 적용

--- a/src/main/java/com/goggles/orderservice/application/service/impl/OrderCommandServiceImpl.java
+++ b/src/main/java/com/goggles/orderservice/application/service/impl/OrderCommandServiceImpl.java
@@ -23,7 +23,6 @@ import com.goggles.orderservice.domain.repository.OrderRepository;
 import jakarta.transaction.Transactional;
 import java.util.List;
 import java.util.UUID;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -56,8 +55,12 @@ public class OrderCommandServiceImpl implements OrderCommandService {
       order = orderRepository.createOrder(order);
       return CreateOrderResult.from(order);
     } catch (Exception e) {
-      log.error("[강의 생성 실패] userId: {}, lectureIds: {}, cause: {}",
-          userInfo.userId(), productInfo.stream().map(ProductReserveInfo::productId).toList(), e.getMessage(), e);
+      log.error(
+          "[강의 생성 실패] userId: {}, lectureIds: {}, cause: {}",
+          userInfo.userId(),
+          productInfo.stream().map(ProductReserveInfo::productId).toList(),
+          e.getMessage(),
+          e);
       compensateLectureReservation(productInfo, userInfo.userId());
       throw e;
     }
@@ -71,17 +74,22 @@ public class OrderCommandServiceImpl implements OrderCommandService {
     OrderItemSpec itemSpec = productInfo.toOrderItemSpec(OrderItemType.MENTORING);
 
     try {
-      Order order = Order.create(
-          new Orderer(userInfo.userId(), userInfo.userName()),
-          null,
-          new OrderPrice(productInfo.productPrice(), 0L),
-          itemSpec);
+      Order order =
+          Order.create(
+              new Orderer(userInfo.userId(), userInfo.userName()),
+              null,
+              new OrderPrice(productInfo.productPrice(), 0L),
+              itemSpec);
 
       order = orderRepository.createOrder(order);
       return CreateOrderResult.from(order);
     } catch (Exception e) {
-      log.error("[멘토링 주문 생성 실패] userId: {}, mentoringId: {}, cause: {}",
-          userInfo.userId(), productInfo.enrollmentId(), e.getMessage(), e);
+      log.error(
+          "[멘토링 주문 생성 실패] userId: {}, mentoringId: {}, cause: {}",
+          userInfo.userId(),
+          productInfo.enrollmentId(),
+          e.getMessage(),
+          e);
       compensateMentoringReservation(productInfo, userInfo.userId());
       throw e;
     }
@@ -124,7 +132,8 @@ public class OrderCommandServiceImpl implements OrderCommandService {
   private void compensateMentoringReservation(ProductReserveInfo productInfo, UUID userId) {
     try {
       mentoringProvider.cancelMentoringBooking(
-          CancelMentoringBookingData.of(userId, productInfo.enrollmentId(), CancelReason.SYSTEM_ERROR));
+          CancelMentoringBookingData.of(
+              userId, productInfo.enrollmentId(), CancelReason.SYSTEM_ERROR));
     } catch (Exception e) {
       log.error("멘토링 예약 보상 트랜잭션 실패. enrollmentId: {}", productInfo.enrollmentId());
       // todo: DLQ 적용

--- a/src/main/java/com/goggles/orderservice/domain/model/CancelReason.java
+++ b/src/main/java/com/goggles/orderservice/domain/model/CancelReason.java
@@ -1,4 +1,4 @@
-package com.goggles.orderservice.application.common;
+package com.goggles.orderservice.domain.model;
 
 import com.goggles.common.exception.BadRequestException;
 

--- a/src/main/java/com/goggles/orderservice/domain/model/CancelReason.java
+++ b/src/main/java/com/goggles/orderservice/domain/model/CancelReason.java
@@ -15,7 +15,7 @@ public enum CancelReason {
     try {
       return CancelReason.valueOf(value.toUpperCase());
     } catch (IllegalArgumentException e) {
-      throw new BadRequestException("유효하지 취소 원인입니다: " + value);
+      throw new BadRequestException("유효하지 않은 취소 원인입니다: " + value);
     }
   }
 }

--- a/src/main/java/com/goggles/orderservice/domain/model/Order.java
+++ b/src/main/java/com/goggles/orderservice/domain/model/Order.java
@@ -1,7 +1,6 @@
 package com.goggles.orderservice.domain.model;
 
 import com.goggles.common.domain.BaseAudit;
-import com.goggles.common.exception.BadRequestException;
 import com.goggles.orderservice.application.common.CancelReason;
 import com.goggles.orderservice.domain.exception.DuplicateOrderItemException;
 import com.goggles.orderservice.domain.exception.InvalidOrderException;

--- a/src/main/java/com/goggles/orderservice/domain/model/Order.java
+++ b/src/main/java/com/goggles/orderservice/domain/model/Order.java
@@ -1,6 +1,8 @@
 package com.goggles.orderservice.domain.model;
 
 import com.goggles.common.domain.BaseAudit;
+import com.goggles.common.exception.BadRequestException;
+import com.goggles.orderservice.application.common.CancelReason;
 import com.goggles.orderservice.domain.exception.DuplicateOrderItemException;
 import com.goggles.orderservice.domain.exception.InvalidOrderException;
 import com.goggles.orderservice.domain.exception.NotFoundOrderItemException;
@@ -15,6 +17,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -41,6 +44,15 @@ public class Order extends BaseAudit {
   @Embedded private OrderPrice price;
 
   @Embedded private Payment payment = null;
+
+  @Column(name = "cancel_reason", length = 20)
+  private CancelReason cancelReason;
+
+  @Column(name = "cancel_description", length = 100)
+  private String cancelDescription;
+
+  @Column(name = "canceled_at")
+  private LocalDateTime canceledAt;
 
   @Enumerated(EnumType.STRING)
   @Column(name = "status", nullable = false, length = 20)
@@ -96,8 +108,11 @@ public class Order extends BaseAudit {
     transitionTo(OrderStatus.PAYMENT_FAILED);
   }
 
-  public void cancel() {
-    transitionTo(OrderStatus.CANCELED);
+  public void cancel(CancelReason reason, String description) {
+    this.cancelReason = reason;
+    this.cancelDescription = description;
+    this.canceledAt = LocalDateTime.now();
+    transitionTo(OrderStatus.PAYMENT_FAILED);
   }
 
   public void cancelItem(UUID itemId) {

--- a/src/main/java/com/goggles/orderservice/domain/model/Order.java
+++ b/src/main/java/com/goggles/orderservice/domain/model/Order.java
@@ -1,7 +1,6 @@
 package com.goggles.orderservice.domain.model;
 
 import com.goggles.common.domain.BaseAudit;
-import com.goggles.orderservice.application.common.CancelReason;
 import com.goggles.orderservice.domain.exception.DuplicateOrderItemException;
 import com.goggles.orderservice.domain.exception.InvalidOrderException;
 import com.goggles.orderservice.domain.exception.NotFoundOrderItemException;
@@ -44,6 +43,7 @@ public class Order extends BaseAudit {
 
   @Embedded private Payment payment = null;
 
+  @Enumerated(EnumType.STRING)
   @Column(name = "cancel_reason", length = 20)
   private CancelReason cancelReason;
 
@@ -111,7 +111,7 @@ public class Order extends BaseAudit {
     this.cancelReason = reason;
     this.cancelDescription = description;
     this.canceledAt = LocalDateTime.now();
-    transitionTo(OrderStatus.PAYMENT_FAILED);
+    transitionTo(OrderStatus.CANCELED);
   }
 
   public void cancelItem(UUID itemId) {

--- a/src/main/java/com/goggles/orderservice/domain/model/OrderStatus.java
+++ b/src/main/java/com/goggles/orderservice/domain/model/OrderStatus.java
@@ -10,13 +10,13 @@ public enum OrderStatus {
   PAYMENT_PENDING("결제 대기") {
     @Override
     public Set<OrderStatus> allowedTransitions() {
-      return EnumSet.of(PAID, PAYMENT_FAILED);
+      return EnumSet.of(PAID, PAYMENT_FAILED, CANCELED);
     }
   },
   PAID("결제 완료") {
     @Override
     public Set<OrderStatus> allowedTransitions() {
-      return EnumSet.of(COMPLETED);
+      return EnumSet.of(COMPLETED, CANCELED);
     }
   },
   COMPLETED("주문 완료") {
@@ -28,7 +28,7 @@ public enum OrderStatus {
   PAYMENT_FAILED("결제 실패") {
     @Override
     public Set<OrderStatus> allowedTransitions() {
-      return EnumSet.of(CANCELED);
+      return EnumSet.noneOf(OrderStatus.class);
     }
   },
   CANCELED("주문 취소") {

--- a/src/main/java/com/goggles/orderservice/infrastructure/client/LectureClient.java
+++ b/src/main/java/com/goggles/orderservice/infrastructure/client/LectureClient.java
@@ -1,5 +1,6 @@
 package com.goggles.orderservice.infrastructure.client;
 
+import com.goggles.orderservice.infrastructure.client.dto.CancelLectureEnrollmentRequest;
 import com.goggles.orderservice.infrastructure.client.dto.ReserveLectureRequest;
 import com.goggles.orderservice.infrastructure.client.dto.ReserveProductResponse;
 import java.util.List;
@@ -11,9 +12,14 @@ import org.springframework.web.bind.annotation.RequestHeader;
 
 @FeignClient(name = "lecture-service")
 public interface LectureClient {
-  @PostMapping("/internal/v1/lectures-enrollment/reserve")
+  @PostMapping("/internal/v1/lectures-enrollment")
   List<ReserveProductResponse> reserveEnrollment(
       @RequestHeader("X-User-Id") UUID userId,
       @RequestHeader("X-User-Role") String userRole,
       @RequestBody ReserveLectureRequest request);
+
+  @PostMapping("/internal/v1/lectures-enrollment/cancellation")
+  void cancelMentoringBooking(
+      @RequestHeader("X-User-Id") UUID userId,
+      @RequestBody CancelLectureEnrollmentRequest request);
 }

--- a/src/main/java/com/goggles/orderservice/infrastructure/client/LectureClient.java
+++ b/src/main/java/com/goggles/orderservice/infrastructure/client/LectureClient.java
@@ -20,5 +20,7 @@ public interface LectureClient {
 
   @PostMapping("/internal/v1/lectures-enrollment/cancellation")
   void cancelLecturesEnrollment(
-      @RequestHeader("X-User-Id") UUID userId, @RequestHeader("X-User-Role") String userRole, @RequestBody CancelLectureEnrollmentRequest request);
+      @RequestHeader("X-User-Id") UUID userId,
+      @RequestHeader("X-User-Role") String userRole,
+      @RequestBody CancelLectureEnrollmentRequest request);
 }

--- a/src/main/java/com/goggles/orderservice/infrastructure/client/LectureClient.java
+++ b/src/main/java/com/goggles/orderservice/infrastructure/client/LectureClient.java
@@ -20,6 +20,5 @@ public interface LectureClient {
 
   @PostMapping("/internal/v1/lectures-enrollment/cancellation")
   void cancelMentoringBooking(
-      @RequestHeader("X-User-Id") UUID userId,
-      @RequestBody CancelLectureEnrollmentRequest request);
+      @RequestHeader("X-User-Id") UUID userId, @RequestBody CancelLectureEnrollmentRequest request);
 }

--- a/src/main/java/com/goggles/orderservice/infrastructure/client/LectureClient.java
+++ b/src/main/java/com/goggles/orderservice/infrastructure/client/LectureClient.java
@@ -19,6 +19,6 @@ public interface LectureClient {
       @RequestBody ReserveLectureRequest request);
 
   @PostMapping("/internal/v1/lectures-enrollment/cancellation")
-  void cancelMentoringBooking(
+  void cancelLecturesEnrollment(
       @RequestHeader("X-User-Id") UUID userId, @RequestBody CancelLectureEnrollmentRequest request);
 }

--- a/src/main/java/com/goggles/orderservice/infrastructure/client/LectureClient.java
+++ b/src/main/java/com/goggles/orderservice/infrastructure/client/LectureClient.java
@@ -20,5 +20,5 @@ public interface LectureClient {
 
   @PostMapping("/internal/v1/lectures-enrollment/cancellation")
   void cancelLecturesEnrollment(
-      @RequestHeader("X-User-Id") UUID userId, @RequestBody CancelLectureEnrollmentRequest request);
+      @RequestHeader("X-User-Id") UUID userId, @RequestHeader("X-User-Role") String userRole, @RequestBody CancelLectureEnrollmentRequest request);
 }

--- a/src/main/java/com/goggles/orderservice/infrastructure/client/LectureClientAdapter.java
+++ b/src/main/java/com/goggles/orderservice/infrastructure/client/LectureClientAdapter.java
@@ -1,5 +1,6 @@
 package com.goggles.orderservice.infrastructure.client;
 
+import com.goggles.orderservice.application.dto.external.CancelLectureEnrollmentData;
 import com.goggles.orderservice.application.dto.external.LectureProductReserveData;
 import com.goggles.orderservice.application.dto.external.ProductReserveInfo;
 import com.goggles.orderservice.application.port.out.LectureProvider;
@@ -30,6 +31,11 @@ public class LectureClientAdapter implements LectureProvider {
             data.userId(), data.userRole().name(), ReserveLectureRequest.from(data));
 
     return responses.stream().map(ReserveProductResponse::toProductItem).toList();
+  }
+
+  @Override
+  public void cancelLectureEnrollment(CancelLectureEnrollmentData data) {
+
   }
 
   private List<ProductReserveInfo> reserveEnrollmentFallback(LectureProductReserveData data, Exception e) {

--- a/src/main/java/com/goggles/orderservice/infrastructure/client/LectureClientAdapter.java
+++ b/src/main/java/com/goggles/orderservice/infrastructure/client/LectureClientAdapter.java
@@ -53,7 +53,7 @@ public class LectureClientAdapter implements LectureProvider {
       fallbackMethod = "cancelLectureEnrollmentFallback")
   @Retry(name = "lecture-service-cancel")
   public void cancelLectureEnrollment(CancelLectureEnrollmentData data) {
-    lectureClient.cancelLecturesEnrollment(data.userId(), CancelLectureEnrollmentRequest.of(data));
+    lectureClient.cancelLecturesEnrollment(data.userId(), data.userRole(), CancelLectureEnrollmentRequest.of(data));
   }
 
   private void cancelLectureEnrollmentFallback(CancelLectureEnrollmentData data, Exception e) {

--- a/src/main/java/com/goggles/orderservice/infrastructure/client/LectureClientAdapter.java
+++ b/src/main/java/com/goggles/orderservice/infrastructure/client/LectureClientAdapter.java
@@ -53,7 +53,8 @@ public class LectureClientAdapter implements LectureProvider {
       fallbackMethod = "cancelLectureEnrollmentFallback")
   @Retry(name = "lecture-service-cancel")
   public void cancelLectureEnrollment(CancelLectureEnrollmentData data) {
-    lectureClient.cancelLecturesEnrollment(data.userId(), data.userRole(), CancelLectureEnrollmentRequest.of(data));
+    lectureClient.cancelLecturesEnrollment(
+        data.userId(), data.userRole(), CancelLectureEnrollmentRequest.of(data));
   }
 
   private void cancelLectureEnrollmentFallback(CancelLectureEnrollmentData data, Exception e) {

--- a/src/main/java/com/goggles/orderservice/infrastructure/client/LectureClientAdapter.java
+++ b/src/main/java/com/goggles/orderservice/infrastructure/client/LectureClientAdapter.java
@@ -34,11 +34,10 @@ public class LectureClientAdapter implements LectureProvider {
   }
 
   @Override
-  public void cancelLectureEnrollment(CancelLectureEnrollmentData data) {
+  public void cancelLectureEnrollment(CancelLectureEnrollmentData data) {}
 
-  }
-
-  private List<ProductReserveInfo> reserveEnrollmentFallback(LectureProductReserveData data, Exception e) {
+  private List<ProductReserveInfo> reserveEnrollmentFallback(
+      LectureProductReserveData data, Exception e) {
     log.warn("lecture-service fallback. cause: {}", e.getMessage());
 
     if (e instanceof CallNotPermittedException) {

--- a/src/main/java/com/goggles/orderservice/infrastructure/client/LectureClientAdapter.java
+++ b/src/main/java/com/goggles/orderservice/infrastructure/client/LectureClientAdapter.java
@@ -5,16 +5,24 @@ import com.goggles.orderservice.application.dto.external.ProductReserveInfo;
 import com.goggles.orderservice.application.port.out.LectureProvider;
 import com.goggles.orderservice.infrastructure.client.dto.ReserveLectureRequest;
 import com.goggles.orderservice.infrastructure.client.dto.ReserveProductResponse;
+import com.goggles.orderservice.infrastructure.client.exception.ExternalServiceException;
+import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
+import io.github.resilience4j.retry.annotation.Retry;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class LectureClientAdapter implements LectureProvider {
   private final LectureClient lectureClient;
 
   @Override
+  @CircuitBreaker(name = "lecture-service-write", fallbackMethod = "reserveEnrollmentFallback")
+  @Retry(name = "lecture-service-write")
   public List<ProductReserveInfo> reserveEnrollment(LectureProductReserveData data) {
 
     List<ReserveProductResponse> responses =
@@ -22,5 +30,17 @@ public class LectureClientAdapter implements LectureProvider {
             data.userId(), data.userRole().name(), ReserveLectureRequest.from(data));
 
     return responses.stream().map(ReserveProductResponse::toProductItem).toList();
+  }
+
+  private List<ProductReserveInfo> reserveEnrollmentFallback(LectureProductReserveData data, Exception e) {
+    log.warn("lecture-service fallback. cause: {}", e.getMessage());
+
+    if (e instanceof CallNotPermittedException) {
+      throw new ExternalServiceException("현재 서비스가 일시적으로 불안정합니다. 잠시 후 다시 시도해주세요.");
+    }
+    if (e instanceof java.net.SocketTimeoutException) {
+      throw new ExternalServiceException("요청 처리 시간이 초과되었습니다. 잠시 후 다시 주문을 시도해주세요.");
+    }
+    throw new ExternalServiceException("주문 처리 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.");
   }
 }

--- a/src/main/java/com/goggles/orderservice/infrastructure/client/LectureClientAdapter.java
+++ b/src/main/java/com/goggles/orderservice/infrastructure/client/LectureClientAdapter.java
@@ -54,7 +54,7 @@ public class LectureClientAdapter implements LectureProvider {
   @Retry(name = "lecture-service-cancel")
   public void cancelLectureEnrollment(CancelLectureEnrollmentData data) {
     lectureClient.cancelLecturesEnrollment(
-        data.userId(), data.userRole(), CancelLectureEnrollmentRequest.of(data));
+        data.userId(), data.userRole().name(), CancelLectureEnrollmentRequest.of(data));
   }
 
   private void cancelLectureEnrollmentFallback(CancelLectureEnrollmentData data, Exception e) {

--- a/src/main/java/com/goggles/orderservice/infrastructure/client/LectureClientAdapter.java
+++ b/src/main/java/com/goggles/orderservice/infrastructure/client/LectureClientAdapter.java
@@ -4,6 +4,8 @@ import com.goggles.orderservice.application.dto.external.CancelLectureEnrollment
 import com.goggles.orderservice.application.dto.external.LectureProductReserveData;
 import com.goggles.orderservice.application.dto.external.ProductReserveInfo;
 import com.goggles.orderservice.application.port.out.LectureProvider;
+import com.goggles.orderservice.infrastructure.client.dto.CancelLectureEnrollmentRequest;
+import com.goggles.orderservice.infrastructure.client.dto.CancelMentoringBookingRequest;
 import com.goggles.orderservice.infrastructure.client.dto.ReserveLectureRequest;
 import com.goggles.orderservice.infrastructure.client.dto.ReserveProductResponse;
 import com.goggles.orderservice.infrastructure.client.exception.ExternalServiceException;
@@ -34,7 +36,9 @@ public class LectureClientAdapter implements LectureProvider {
   }
 
   @Override
-  public void cancelLectureEnrollment(CancelLectureEnrollmentData data) {}
+  public void cancelLectureEnrollment(CancelLectureEnrollmentData data) {
+    lectureClient.cancelLecturesEnrollment(data.userId(), CancelLectureEnrollmentRequest.of(data));
+  }
 
   private List<ProductReserveInfo> reserveEnrollmentFallback(
       LectureProductReserveData data, Exception e) {

--- a/src/main/java/com/goggles/orderservice/infrastructure/client/LectureClientAdapter.java
+++ b/src/main/java/com/goggles/orderservice/infrastructure/client/LectureClientAdapter.java
@@ -5,7 +5,6 @@ import com.goggles.orderservice.application.dto.external.LectureProductReserveDa
 import com.goggles.orderservice.application.dto.external.ProductReserveInfo;
 import com.goggles.orderservice.application.port.out.LectureProvider;
 import com.goggles.orderservice.infrastructure.client.dto.CancelLectureEnrollmentRequest;
-import com.goggles.orderservice.infrastructure.client.dto.CancelMentoringBookingRequest;
 import com.goggles.orderservice.infrastructure.client.dto.ReserveLectureRequest;
 import com.goggles.orderservice.infrastructure.client.dto.ReserveProductResponse;
 import com.goggles.orderservice.infrastructure.client.exception.ExternalServiceException;
@@ -49,19 +48,22 @@ public class LectureClientAdapter implements LectureProvider {
   }
 
   @Override
-  @CircuitBreaker(name = "lecture-service-cancel", fallbackMethod = "cancelLectureEnrollmentFallback")
+  @CircuitBreaker(
+      name = "lecture-service-cancel",
+      fallbackMethod = "cancelLectureEnrollmentFallback")
   @Retry(name = "lecture-service-cancel")
   public void cancelLectureEnrollment(CancelLectureEnrollmentData data) {
     lectureClient.cancelLecturesEnrollment(data.userId(), CancelLectureEnrollmentRequest.of(data));
   }
 
   private void cancelLectureEnrollmentFallback(CancelLectureEnrollmentData data, Exception e) {
-    log.error("[강의 등록 취소 보상 트랜잭션 최종 실패] " +
-            "userId: {}, enrollmentId: {}, cancelReason: {}, cause: {}",
+    log.error(
+        "[강의 등록 취소 보상 트랜잭션 최종 실패] " + "userId: {}, enrollmentId: {}, cancelReason: {}, cause: {}",
         data.userId(),
         data.LectureEnrollmentIds(),
         data.cancelReason(),
-        e.getMessage(), e);
+        e.getMessage(),
+        e);
 
     throw new ExternalServiceException("강의 등록 취소 처리 중 오류가 발생했습니다.");
   }

--- a/src/main/java/com/goggles/orderservice/infrastructure/client/LectureClientAdapter.java
+++ b/src/main/java/com/goggles/orderservice/infrastructure/client/LectureClientAdapter.java
@@ -35,11 +35,6 @@ public class LectureClientAdapter implements LectureProvider {
     return responses.stream().map(ReserveProductResponse::toProductItem).toList();
   }
 
-  @Override
-  public void cancelLectureEnrollment(CancelLectureEnrollmentData data) {
-    lectureClient.cancelLecturesEnrollment(data.userId(), CancelLectureEnrollmentRequest.of(data));
-  }
-
   private List<ProductReserveInfo> reserveEnrollmentFallback(
       LectureProductReserveData data, Exception e) {
     log.warn("lecture-service fallback. cause: {}", e.getMessage());
@@ -51,5 +46,23 @@ public class LectureClientAdapter implements LectureProvider {
       throw new ExternalServiceException("요청 처리 시간이 초과되었습니다. 잠시 후 다시 주문을 시도해주세요.");
     }
     throw new ExternalServiceException("주문 처리 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.");
+  }
+
+  @Override
+  @CircuitBreaker(name = "lecture-service-cancel", fallbackMethod = "cancelLectureEnrollmentFallback")
+  @Retry(name = "lecture-service-cancel")
+  public void cancelLectureEnrollment(CancelLectureEnrollmentData data) {
+    lectureClient.cancelLecturesEnrollment(data.userId(), CancelLectureEnrollmentRequest.of(data));
+  }
+
+  private void cancelLectureEnrollmentFallback(CancelLectureEnrollmentData data, Exception e) {
+    log.error("[강의 등록 취소 보상 트랜잭션 최종 실패] " +
+            "userId: {}, enrollmentId: {}, cancelReason: {}, cause: {}",
+        data.userId(),
+        data.LectureEnrollmentIds(),
+        data.cancelReason(),
+        e.getMessage(), e);
+
+    throw new ExternalServiceException("강의 등록 취소 처리 중 오류가 발생했습니다.");
   }
 }

--- a/src/main/java/com/goggles/orderservice/infrastructure/client/MentoringClient.java
+++ b/src/main/java/com/goggles/orderservice/infrastructure/client/MentoringClient.java
@@ -10,7 +10,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestParam;
 
 @FeignClient(name = "mentoring-service")
 public interface MentoringClient {

--- a/src/main/java/com/goggles/orderservice/infrastructure/client/MentoringClient.java
+++ b/src/main/java/com/goggles/orderservice/infrastructure/client/MentoringClient.java
@@ -1,5 +1,6 @@
 package com.goggles.orderservice.infrastructure.client;
 
+import com.goggles.orderservice.infrastructure.client.dto.CancelMentoringBookingRequest;
 import com.goggles.orderservice.infrastructure.client.dto.ReserveMentoringRequest;
 import com.goggles.orderservice.infrastructure.client.dto.ReserveProductResponse;
 import java.util.UUID;
@@ -16,4 +17,9 @@ public interface MentoringClient {
       @RequestHeader("X-User-Role") String userRole,
       @RequestHeader("X-User-Name") String userName,
       @RequestBody ReserveMentoringRequest request);
+
+  @PostMapping("/internal/v1/mentoring-booking/cancellation")
+  void cancelMentoringBooking(
+      @RequestHeader("X-User-Id") UUID userId,
+      @RequestBody CancelMentoringBookingRequest request);
 }

--- a/src/main/java/com/goggles/orderservice/infrastructure/client/MentoringClient.java
+++ b/src/main/java/com/goggles/orderservice/infrastructure/client/MentoringClient.java
@@ -6,9 +6,11 @@ import com.goggles.orderservice.infrastructure.client.dto.ReserveProductResponse
 import java.util.UUID;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @FeignClient(name = "mentoring-service")
 public interface MentoringClient {
@@ -19,7 +21,10 @@ public interface MentoringClient {
       @RequestHeader("X-User-Name") String userName,
       @RequestBody ReserveMentoringRequest request);
 
-  @PatchMapping("/internal/v1/mentoring-booking/cancellation")
+  @PatchMapping("/internal/v1/mentoring-booking/{bookingId}/cancellation")
   void cancelMentoringBooking(
-      @RequestHeader("X-User-Id") UUID userId, @RequestBody CancelMentoringBookingRequest request);
+      @RequestHeader("X-User-Id") UUID userId,
+      @RequestHeader("X-User-Role") String userRole,
+      @PathVariable("bookingId") UUID bookingId,
+      @RequestBody CancelMentoringBookingRequest request);
 }

--- a/src/main/java/com/goggles/orderservice/infrastructure/client/MentoringClient.java
+++ b/src/main/java/com/goggles/orderservice/infrastructure/client/MentoringClient.java
@@ -5,6 +5,7 @@ import com.goggles.orderservice.infrastructure.client.dto.ReserveMentoringReques
 import com.goggles.orderservice.infrastructure.client.dto.ReserveProductResponse;
 import java.util.UUID;
 import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -18,7 +19,7 @@ public interface MentoringClient {
       @RequestHeader("X-User-Name") String userName,
       @RequestBody ReserveMentoringRequest request);
 
-  @PostMapping("/internal/v1/mentoring-booking/cancellation")
+  @PatchMapping("/internal/v1/mentoring-booking/cancellation")
   void cancelMentoringBooking(
       @RequestHeader("X-User-Id") UUID userId, @RequestBody CancelMentoringBookingRequest request);
 }

--- a/src/main/java/com/goggles/orderservice/infrastructure/client/MentoringClient.java
+++ b/src/main/java/com/goggles/orderservice/infrastructure/client/MentoringClient.java
@@ -20,6 +20,5 @@ public interface MentoringClient {
 
   @PostMapping("/internal/v1/mentoring-booking/cancellation")
   void cancelMentoringBooking(
-      @RequestHeader("X-User-Id") UUID userId,
-      @RequestBody CancelMentoringBookingRequest request);
+      @RequestHeader("X-User-Id") UUID userId, @RequestBody CancelMentoringBookingRequest request);
 }

--- a/src/main/java/com/goggles/orderservice/infrastructure/client/MentoringClientAdapter.java
+++ b/src/main/java/com/goggles/orderservice/infrastructure/client/MentoringClientAdapter.java
@@ -42,7 +42,7 @@ public class MentoringClientAdapter implements MentoringProvider {
     mentoringClient.cancelMentoringBooking(data.userId(), CancelMentoringBookingRequest.of(data));
   }
 
-  private List<ProductReserveInfo> reserveEnrollmentFallback(
+  private ProductReserveInfo reserveEnrollmentFallback(
       MentoringProductReserveData data, Exception e) {
     log.warn("mentoring-service circuit breaker fallback. cause: {}", e.getMessage());
 

--- a/src/main/java/com/goggles/orderservice/infrastructure/client/MentoringClientAdapter.java
+++ b/src/main/java/com/goggles/orderservice/infrastructure/client/MentoringClientAdapter.java
@@ -11,7 +11,6 @@ import com.goggles.orderservice.infrastructure.client.exception.ExternalServiceE
 import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
 import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
 import io.github.resilience4j.retry.annotation.Retry;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -51,19 +50,22 @@ public class MentoringClientAdapter implements MentoringProvider {
   }
 
   @Override
-  @CircuitBreaker(name = "mentoring-service-cancel", fallbackMethod = "cancelMentoringBookingFallback")
+  @CircuitBreaker(
+      name = "mentoring-service-cancel",
+      fallbackMethod = "cancelMentoringBookingFallback")
   @Retry(name = "mentoring-service-cancel")
   public void cancelMentoringBooking(CancelMentoringBookingData data) {
     mentoringClient.cancelMentoringBooking(data.userId(), CancelMentoringBookingRequest.of(data));
   }
 
   private void cancelMentoringBookingFallback(CancelMentoringBookingData data, Exception e) {
-    log.error("[멘토링 취소 보상 트랜잭션 최종 실패] " +
-            "userId: {}, enrollmentId: {}, cancelReason: {}, cause: {}",
+    log.error(
+        "[멘토링 취소 보상 트랜잭션 최종 실패] " + "userId: {}, enrollmentId: {}, cancelReason: {}, cause: {}",
         data.userId(),
         data.mentoringBookingId(),
         data.cancelReason(),
-        e.getMessage(), e);
+        e.getMessage(),
+        e);
 
     throw new ExternalServiceException("멘토링 취소 처리 중 오류가 발생했습니다.");
   }

--- a/src/main/java/com/goggles/orderservice/infrastructure/client/MentoringClientAdapter.java
+++ b/src/main/java/com/goggles/orderservice/infrastructure/client/MentoringClientAdapter.java
@@ -42,7 +42,8 @@ public class MentoringClientAdapter implements MentoringProvider {
     mentoringClient.cancelMentoringBooking(data.userId(), CancelMentoringBookingRequest.of(data));
   }
 
-  private List<ProductReserveInfo> reserveEnrollmentFallback(MentoringProductReserveData data, Exception e) {
+  private List<ProductReserveInfo> reserveEnrollmentFallback(
+      MentoringProductReserveData data, Exception e) {
     log.warn("mentoring-service circuit breaker fallback. cause: {}", e.getMessage());
 
     if (e instanceof CallNotPermittedException) {

--- a/src/main/java/com/goggles/orderservice/infrastructure/client/MentoringClientAdapter.java
+++ b/src/main/java/com/goggles/orderservice/infrastructure/client/MentoringClientAdapter.java
@@ -5,16 +5,25 @@ import com.goggles.orderservice.application.dto.external.ProductReserveInfo;
 import com.goggles.orderservice.application.port.out.MentoringProvider;
 import com.goggles.orderservice.infrastructure.client.dto.ReserveMentoringRequest;
 import com.goggles.orderservice.infrastructure.client.dto.ReserveProductResponse;
+import com.goggles.orderservice.infrastructure.client.exception.ExternalServiceException;
+import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
+import io.github.resilience4j.retry.annotation.Retry;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class MentoringClientAdapter implements MentoringProvider {
 
   private final MentoringClient mentoringClient;
 
   @Override
+  @CircuitBreaker(name = "mentoring-service-write", fallbackMethod = "reserveEnrollmentFallback")
+  @Retry(name = "mentoring-service-write")
   public ProductReserveInfo reserveEnrollment(MentoringProductReserveData data) {
     ReserveProductResponse response =
         mentoringClient.reserveEnrollment(
@@ -24,5 +33,17 @@ public class MentoringClientAdapter implements MentoringProvider {
             ReserveMentoringRequest.from(data));
 
     return response.toProductItem();
+  }
+
+  private List<ProductReserveInfo> reserveEnrollmentFallback(MentoringProductReserveData data, Exception e) {
+    log.warn("mentoring-service circuit breaker fallback. cause: {}", e.getMessage());
+
+    if (e instanceof CallNotPermittedException) {
+      throw new ExternalServiceException("현재 서비스가 일시적으로 불안정합니다. 잠시 후 다시 시도해주세요.");
+    }
+    if (e instanceof java.net.SocketTimeoutException) {
+      throw new ExternalServiceException("요청 처리 시간이 초과되었습니다. 잠시 후 다시 주문을 시도해주세요.");
+    }
+    throw new ExternalServiceException("주문 처리 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.");
   }
 }

--- a/src/main/java/com/goggles/orderservice/infrastructure/client/MentoringClientAdapter.java
+++ b/src/main/java/com/goggles/orderservice/infrastructure/client/MentoringClientAdapter.java
@@ -1,8 +1,10 @@
 package com.goggles.orderservice.infrastructure.client;
 
+import com.goggles.orderservice.application.dto.external.CancelMentoringBookingData;
 import com.goggles.orderservice.application.dto.external.MentoringProductReserveData;
 import com.goggles.orderservice.application.dto.external.ProductReserveInfo;
 import com.goggles.orderservice.application.port.out.MentoringProvider;
+import com.goggles.orderservice.infrastructure.client.dto.CancelMentoringBookingRequest;
 import com.goggles.orderservice.infrastructure.client.dto.ReserveMentoringRequest;
 import com.goggles.orderservice.infrastructure.client.dto.ReserveProductResponse;
 import com.goggles.orderservice.infrastructure.client.exception.ExternalServiceException;
@@ -33,6 +35,11 @@ public class MentoringClientAdapter implements MentoringProvider {
             ReserveMentoringRequest.from(data));
 
     return response.toProductItem();
+  }
+
+  @Override
+  public void cancelMentoringBooking(CancelMentoringBookingData data) {
+    mentoringClient.cancelMentoringBooking(data.userId(), CancelMentoringBookingRequest.of(data));
   }
 
   private List<ProductReserveInfo> reserveEnrollmentFallback(MentoringProductReserveData data, Exception e) {

--- a/src/main/java/com/goggles/orderservice/infrastructure/client/MentoringClientAdapter.java
+++ b/src/main/java/com/goggles/orderservice/infrastructure/client/MentoringClientAdapter.java
@@ -37,11 +37,6 @@ public class MentoringClientAdapter implements MentoringProvider {
     return response.toProductItem();
   }
 
-  @Override
-  public void cancelMentoringBooking(CancelMentoringBookingData data) {
-    mentoringClient.cancelMentoringBooking(data.userId(), CancelMentoringBookingRequest.of(data));
-  }
-
   private ProductReserveInfo reserveEnrollmentFallback(
       MentoringProductReserveData data, Exception e) {
     log.warn("mentoring-service circuit breaker fallback. cause: {}", e.getMessage());
@@ -53,5 +48,23 @@ public class MentoringClientAdapter implements MentoringProvider {
       throw new ExternalServiceException("요청 처리 시간이 초과되었습니다. 잠시 후 다시 주문을 시도해주세요.");
     }
     throw new ExternalServiceException("주문 처리 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.");
+  }
+
+  @Override
+  @CircuitBreaker(name = "mentoring-service-cancel", fallbackMethod = "cancelMentoringBookingFallback")
+  @Retry(name = "mentoring-service-cancel")
+  public void cancelMentoringBooking(CancelMentoringBookingData data) {
+    mentoringClient.cancelMentoringBooking(data.userId(), CancelMentoringBookingRequest.of(data));
+  }
+
+  private void cancelMentoringBookingFallback(CancelMentoringBookingData data, Exception e) {
+    log.error("[멘토링 취소 보상 트랜잭션 최종 실패] " +
+            "userId: {}, enrollmentId: {}, cancelReason: {}, cause: {}",
+        data.userId(),
+        data.mentoringBookingId(),
+        data.cancelReason(),
+        e.getMessage(), e);
+
+    throw new ExternalServiceException("멘토링 취소 처리 중 오류가 발생했습니다.");
   }
 }

--- a/src/main/java/com/goggles/orderservice/infrastructure/client/MentoringClientAdapter.java
+++ b/src/main/java/com/goggles/orderservice/infrastructure/client/MentoringClientAdapter.java
@@ -55,7 +55,11 @@ public class MentoringClientAdapter implements MentoringProvider {
       fallbackMethod = "cancelMentoringBookingFallback")
   @Retry(name = "mentoring-service-cancel")
   public void cancelMentoringBooking(CancelMentoringBookingData data) {
-    mentoringClient.cancelMentoringBooking(data.userId(), CancelMentoringBookingRequest.of(data));
+    mentoringClient.cancelMentoringBooking(
+        data.userId(),
+        data.userRole().name(),
+        data.mentoringBookingId(),
+        CancelMentoringBookingRequest.of(data));
   }
 
   private void cancelMentoringBookingFallback(CancelMentoringBookingData data, Exception e) {

--- a/src/main/java/com/goggles/orderservice/infrastructure/client/UserClientAdapter.java
+++ b/src/main/java/com/goggles/orderservice/infrastructure/client/UserClientAdapter.java
@@ -3,19 +3,38 @@ package com.goggles.orderservice.infrastructure.client;
 import com.goggles.orderservice.application.dto.external.UserInfo;
 import com.goggles.orderservice.application.port.out.UserReader;
 import com.goggles.orderservice.infrastructure.client.dto.GetUserInfoResponse;
+import com.goggles.orderservice.infrastructure.client.exception.ExternalServiceException;
+import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
+import io.github.resilience4j.retry.annotation.Retry;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class UserClientAdapter implements UserReader {
 
   private final UserClient userClient;
 
   @Override
+  @CircuitBreaker(name = "user-service-read", fallbackMethod = "getUserInfoFallback")
+  @Retry(name = "user-service-read")
   public UserInfo getUserInfo(UUID userId) {
     GetUserInfoResponse response = userClient.getUserInfo(userId);
     return response.toUserInfo();
+  }
+
+  private UserInfo getUserInfoFallback(UUID userId, Exception e) {
+    log.warn("user-service circuit breaker fallback. cause: {}", e.getMessage());
+    if (e instanceof CallNotPermittedException) {
+      throw new ExternalServiceException("현재 서비스가 일시적으로 불안정합니다. 잠시 후 다시 시도해주세요.");
+    }
+    if (e instanceof java.net.SocketTimeoutException) {
+      throw new ExternalServiceException("요청 처리 시간이 초과되었습니다. 잠시 후 다시 주문을 시도해주세요.");
+    }
+    throw new ExternalServiceException("주문 처리 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.");
   }
 }

--- a/src/main/java/com/goggles/orderservice/infrastructure/client/dto/CancelLectureEnrollmentRequest.java
+++ b/src/main/java/com/goggles/orderservice/infrastructure/client/dto/CancelLectureEnrollmentRequest.java
@@ -16,6 +16,6 @@ public class CancelLectureEnrollmentRequest {
 
   public static CancelLectureEnrollmentRequest of(CancelLectureEnrollmentData data) {
     return new CancelLectureEnrollmentRequest(
-        data.mentoringBookingIds(), data.cancelReason().name());
+        data.LectureEnrollmentIds(), data.cancelReason().name());
   }
 }

--- a/src/main/java/com/goggles/orderservice/infrastructure/client/dto/CancelLectureEnrollmentRequest.java
+++ b/src/main/java/com/goggles/orderservice/infrastructure/client/dto/CancelLectureEnrollmentRequest.java
@@ -1,0 +1,23 @@
+package com.goggles.orderservice.infrastructure.client.dto;
+
+import com.goggles.orderservice.application.dto.external.CancelLectureEnrollmentData;
+import java.util.List;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CancelLectureEnrollmentRequest {
+  private List<UUID> mentoringBookingIds;
+  private String cancelReason;
+
+  public static CancelLectureEnrollmentRequest of(CancelLectureEnrollmentData data) {
+    return new CancelLectureEnrollmentRequest(
+        data.mentoringBookingIds(),
+        data.cancelReason().name()
+    );
+  }
+}

--- a/src/main/java/com/goggles/orderservice/infrastructure/client/dto/CancelLectureEnrollmentRequest.java
+++ b/src/main/java/com/goggles/orderservice/infrastructure/client/dto/CancelLectureEnrollmentRequest.java
@@ -16,8 +16,6 @@ public class CancelLectureEnrollmentRequest {
 
   public static CancelLectureEnrollmentRequest of(CancelLectureEnrollmentData data) {
     return new CancelLectureEnrollmentRequest(
-        data.mentoringBookingIds(),
-        data.cancelReason().name()
-    );
+        data.mentoringBookingIds(), data.cancelReason().name());
   }
 }

--- a/src/main/java/com/goggles/orderservice/infrastructure/client/dto/CancelMentoringBookingRequest.java
+++ b/src/main/java/com/goggles/orderservice/infrastructure/client/dto/CancelMentoringBookingRequest.java
@@ -1,7 +1,6 @@
 package com.goggles.orderservice.infrastructure.client.dto;
 
 import com.goggles.orderservice.application.dto.external.CancelMentoringBookingData;
-import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,10 +9,9 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class CancelMentoringBookingRequest {
-  private UUID mentoringBookingId;
   private String cancelReason;
 
   public static CancelMentoringBookingRequest of(CancelMentoringBookingData data) {
-    return new CancelMentoringBookingRequest(data.mentoringBookingId(), data.cancelReason().name());
+    return new CancelMentoringBookingRequest(data.cancelReason().name());
   }
 }

--- a/src/main/java/com/goggles/orderservice/infrastructure/client/dto/CancelMentoringBookingRequest.java
+++ b/src/main/java/com/goggles/orderservice/infrastructure/client/dto/CancelMentoringBookingRequest.java
@@ -1,0 +1,19 @@
+package com.goggles.orderservice.infrastructure.client.dto;
+
+import com.goggles.orderservice.application.dto.external.CancelMentoringBookingData;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CancelMentoringBookingRequest {
+  private UUID mentoringBookingId;
+  private String cancelReason;
+
+  public static CancelMentoringBookingRequest of(CancelMentoringBookingData data) {
+    return new CancelMentoringBookingRequest(data.mentoringBookingId(), data.cancelReason().name());
+  }
+}

--- a/src/main/java/com/goggles/orderservice/infrastructure/client/exception/ExternalServiceException.java
+++ b/src/main/java/com/goggles/orderservice/infrastructure/client/exception/ExternalServiceException.java
@@ -1,0 +1,10 @@
+package com.goggles.orderservice.infrastructure.client.exception;
+
+import com.goggles.common.exception.InternalServerException;
+
+public class ExternalServiceException extends InternalServerException {
+
+  public ExternalServiceException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/com/goggles/orderservice/presentation/dto/CreateLectureOrderRequest.java
+++ b/src/main/java/com/goggles/orderservice/presentation/dto/CreateLectureOrderRequest.java
@@ -1,5 +1,6 @@
 package com.goggles.orderservice.presentation.dto;
 
+import com.goggles.orderservice.application.common.UserRole;
 import com.goggles.orderservice.application.dto.command.CreateLectureOrderCommand;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -15,6 +16,6 @@ public record CreateLectureOrderRequest(
 
   public CreateLectureOrderCommand toCommand(UUID userId, String userRole) {
     return new CreateLectureOrderCommand(
-        userId, userRole, this.couponId, this.paymentMethod, this.items);
+        userId, UserRole.from(userRole), this.couponId, this.paymentMethod, this.items);
   }
 }

--- a/src/main/java/com/goggles/orderservice/presentation/dto/CreateMentoringOrderRequest.java
+++ b/src/main/java/com/goggles/orderservice/presentation/dto/CreateMentoringOrderRequest.java
@@ -1,5 +1,6 @@
 package com.goggles.orderservice.presentation.dto;
 
+import com.goggles.orderservice.application.common.UserRole;
 import com.goggles.orderservice.application.dto.command.CreateMentoringOrderCommand;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -25,7 +26,7 @@ public record CreateMentoringOrderRequest(
   public CreateMentoringOrderCommand toCommand(UUID userId, String userRole) {
     return new CreateMentoringOrderCommand(
         userId,
-        userRole,
+        UserRole.from(userRole),
         this.mentoringId,
         this.requestMessage,
         this.couponId,

--- a/src/main/java/com/goggles/orderservice/presentation/dto/OrderDetailResponse.java
+++ b/src/main/java/com/goggles/orderservice/presentation/dto/OrderDetailResponse.java
@@ -20,6 +20,9 @@ public record OrderDetailResponse(
     String paymentMethod,
     LocalDateTime orderDate,
     String orderStatus,
+    String cancelReason,
+    String cancelDescription,
+    LocalDateTime canceledAt,
     List<OrderItemSummaryResponse> orderItems) {
   public static OrderDetailResponse from(OrderDetailResult result) {
     return new OrderDetailResponse(
@@ -36,6 +39,9 @@ public record OrderDetailResponse(
         result.payment() != null ? result.payment().getPaymentMethod() : null,
         result.createdAt(),
         result.status().getDisplayName(),
+        result.cancelReason() != null ? result.cancelReason().name() : null,
+        result.cancelDescription() != null ? result.cancelDescription() : null,
+        result.canceledAt() != null ? result.canceledAt() : null,
         result.orderItems().stream().map(OrderItemSummaryResponse::from).toList());
   }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -105,11 +105,48 @@ resilience4j:
           - org.springframework.http.converter.HttpMessageNotReadableException
           - java.lang.IllegalArgumentException
 
+      default-cancel:
+        slidingWindowType: COUNT_BASED
+        slidingWindowSize: 10
+        minimumNumberOfCalls: 5
+        failureRateThreshold: 30
+        waitDurationInOpenState: 60s
+
+        slowCallDurationThreshold: 3s
+        slowCallRateThreshold: 50
+        permittedNumberOfCallsInHalfOpenState: 2
+        automaticTransitionFromOpenToHalfOpenEnabled: true
+        eventConsumerBufferSize: 10
+
+        recordExceptions:
+          - java.net.SocketTimeoutException
+          - feign.FeignException.InternalServerError
+          - feign.FeignException.ServiceUnavailable
+          - feign.FeignException.GatewayTimeout
+          - feign.RetryableException
+        ignoreExceptions:
+          # common business exception
+          - com.goggles.common.exception.BadRequestException
+          - com.goggles.common.exception.ConflictException
+          - com.goggles.common.exception.ForbiddenException
+          - com.goggles.common.exception.NotFoundException
+          - com.goggles.common.exception.UnAuthorizedException
+
+          # Spring/Jakarta validation exception
+          - org.springframework.web.bind.MethodArgumentNotValidException
+          - jakarta.validation.ConstraintViolationException
+          - org.springframework.http.converter.HttpMessageNotReadableException
+          - java.lang.IllegalArgumentException
+
     instances:
       lecture-service-write:
         baseConfig: default-write
       mentoring-service-write:
         baseConfig: default-write
+      lecture-service-cancel:
+        baseConfig: default-cancel
+      mentoring-service-cancel:
+        baseConfig: default-cancel
       user-service-read:
         baseConfig: default-read
 
@@ -139,11 +176,40 @@ resilience4j:
           - jakarta.validation.ConstraintViolationException
           - org.springframework.http.converter.HttpMessageNotReadableException
           - java.lang.IllegalArgumentException
+
+      default-cancel:
+        maxAttempts: 2
+        waitDuration: 2s
+        enableExponentialBackoff: true
+        exponentialBackoffMultiplier: 2.0
+        retryExceptions:
+          - java.net.SocketTimeoutException
+          - feign.FeignException.InternalServerError
+          - feign.FeignException.ServiceUnavailable
+          - feign.FeignException.GatewayTimeout
+          - feign.RetryableException
+        ignoreExceptions:
+          # common business exception
+          - com.goggles.common.exception.BadRequestException
+          - com.goggles.common.exception.ConflictException
+          - com.goggles.common.exception.ForbiddenException
+          - com.goggles.common.exception.NotFoundException
+          - com.goggles.common.exception.UnAuthorizedException
+
+          # Spring/Jakarta validation exception
+          - org.springframework.web.bind.MethodArgumentNotValidException
+          - jakarta.validation.ConstraintViolationException
+          - org.springframework.http.converter.HttpMessageNotReadableException
+          - java.lang.IllegalArgumentException
     instances:
       lecture-service-write:
         baseConfig: default
       mentoring-service-write:
         baseConfig: default
+      lecture-service-cancel:
+        baseConfig: default-cancel
+      mentoring-service-cancel:
+        baseConfig: default-cancel
       user-service-read:
         baseConfig: default
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -10,6 +10,7 @@ spring:
     username: ${DB_USERNAME:postgres}
     password: ${DB_PASSWORD:postgres}
 
+
   jpa:
     properties:
       hibernate:
@@ -21,6 +22,124 @@ spring:
       ddl-auto: update
     open-in-view: false
     generate-ddl: true
+
+  cloud:
+    openfeign:
+      circuitbreaker:
+        enabled: true
+
+feign:
+  client:
+    default:
+      connectTimeout: 5000
+      readTimeout: 2000
+      loggerLevel: full
+
+
+resilience4j:
+  circuitbreaker:
+    configs:
+      default-read:
+        slidingWindowType: COUNT_BASED
+        slidingWindowSize: 10
+        minimumNumberOfCalls: 5
+        failureRateThreshold: 50
+        waitDurationInOpenState: 30s
+
+        slowCallDurationThreshold: 3s    # 3초 이상이면 느린 호출로 간주
+        slowCallRateThreshold: 50        # 느린 호출이 50% 이상이면 차단
+        permittedNumberOfCallsInHalfOpenState: 2  # 반개방 상태 테스트 호출 수
+        automaticTransitionFromOpenToHalfOpenEnabled: true  # 자동 전환
+        eventConsumerBufferSize: 10
+
+        recordExceptions:
+          - java.net.SocketTimeoutException
+          - org.springframework.web.client.HttpServerErrorException
+          - feign.RetryableException
+        ignoreExceptions:
+          # common business exception
+          - com.goggles.common.exception.BadRequestException
+          - com.goggles.common.exception.ConflictException
+          - com.goggles.common.exception.ForbiddenException
+          - com.goggles.common.exception.NotFoundException
+          - com.goggles.common.exception.UnAuthorizedException
+
+          # Spring/Jakarta validation exception
+          - org.springframework.web.bind.MethodArgumentNotValidException
+          - jakarta.validation.ConstraintViolationException
+          - org.springframework.http.converter.HttpMessageNotReadableException
+          - java.lang.IllegalArgumentException
+
+      default-write:
+        slidingWindowType: COUNT_BASED
+        slidingWindowSize: 10
+        minimumNumberOfCalls: 5
+        failureRateThreshold: 30
+        waitDurationInOpenState: 60s
+
+        slowCallDurationThreshold: 3s    # 3초 이상이면 느린 호출로 간주
+        slowCallRateThreshold: 50        # 느린 호출이 50% 이상이면 차단
+        permittedNumberOfCallsInHalfOpenState: 2  # 반개방 상태 테스트 호출 수
+        automaticTransitionFromOpenToHalfOpenEnabled: true  # 자동 전환
+        eventConsumerBufferSize: 10
+
+        recordExceptions:
+          - java.net.SocketTimeoutException
+          - org.springframework.web.client.HttpServerErrorException
+          - feign.RetryableException
+        ignoreExceptions:
+          # common business exception
+          - com.goggles.common.exception.BadRequestException
+          - com.goggles.common.exception.ConflictException
+          - com.goggles.common.exception.ForbiddenException
+          - com.goggles.common.exception.NotFoundException
+          - com.goggles.common.exception.UnAuthorizedException
+
+          # Spring/Jakarta validation exception
+          - org.springframework.web.bind.MethodArgumentNotValidException
+          - jakarta.validation.ConstraintViolationException
+          - org.springframework.http.converter.HttpMessageNotReadableException
+          - java.lang.IllegalArgumentException
+
+    instances:
+      lecture-service-write:
+        baseConfig: default-write
+      mentoring-service-write:
+        baseConfig: default-write
+      user-service-read:
+        baseConfig: default-read
+
+  retry:
+    configs:
+      default:
+        maxAttempts: 3
+        waitDuration: 1s
+        enableExponentialBackoff: true
+        exponentialBackoffMultiplier: 2.0
+        retryExceptions:
+          - java.net.SocketTimeoutException
+          - org.springframework.web.client.HttpServerErrorException
+          - feign.RetryableException
+        ignoreExceptions:
+          # common business exception
+          - com.goggles.common.exception.BadRequestException
+          - com.goggles.common.exception.ConflictException
+          - com.goggles.common.exception.ForbiddenException
+          - com.goggles.common.exception.NotFoundException
+          - com.goggles.common.exception.UnAuthorizedException
+
+          # Spring/Jakarta validation exception
+          - org.springframework.web.bind.MethodArgumentNotValidException
+          - jakarta.validation.ConstraintViolationException
+          - org.springframework.http.converter.HttpMessageNotReadableException
+          - java.lang.IllegalArgumentException
+    instances:
+      lecture-service-write:
+        baseConfig: default
+      mentoring-service-write:
+        baseConfig: default
+      user-service-read:
+        baseConfig: default
 
 server:
   port: 9007

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -46,15 +46,17 @@ resilience4j:
         failureRateThreshold: 50
         waitDurationInOpenState: 30s
 
-        slowCallDurationThreshold: 3s    # 3초 이상이면 느린 호출로 간주
-        slowCallRateThreshold: 50        # 느린 호출이 50% 이상이면 차단
-        permittedNumberOfCallsInHalfOpenState: 2  # 반개방 상태 테스트 호출 수
-        automaticTransitionFromOpenToHalfOpenEnabled: true  # 자동 전환
+        slowCallDurationThreshold: 3s
+        slowCallRateThreshold: 50
+        permittedNumberOfCallsInHalfOpenState: 2
+        automaticTransitionFromOpenToHalfOpenEnabled: true
         eventConsumerBufferSize: 10
 
         recordExceptions:
           - java.net.SocketTimeoutException
-          - org.springframework.web.client.HttpServerErrorException
+          - feign.FeignException.InternalServerError
+          - feign.FeignException.ServiceUnavailable
+          - feign.FeignException.GatewayTimeout
           - feign.RetryableException
         ignoreExceptions:
           # common business exception
@@ -77,15 +79,17 @@ resilience4j:
         failureRateThreshold: 30
         waitDurationInOpenState: 60s
 
-        slowCallDurationThreshold: 3s    # 3초 이상이면 느린 호출로 간주
-        slowCallRateThreshold: 50        # 느린 호출이 50% 이상이면 차단
-        permittedNumberOfCallsInHalfOpenState: 2  # 반개방 상태 테스트 호출 수
-        automaticTransitionFromOpenToHalfOpenEnabled: true  # 자동 전환
+        slowCallDurationThreshold: 3s
+        slowCallRateThreshold: 50
+        permittedNumberOfCallsInHalfOpenState: 2
+        automaticTransitionFromOpenToHalfOpenEnabled: true
         eventConsumerBufferSize: 10
 
         recordExceptions:
           - java.net.SocketTimeoutException
-          - org.springframework.web.client.HttpServerErrorException
+          - feign.FeignException.InternalServerError
+          - feign.FeignException.ServiceUnavailable
+          - feign.FeignException.GatewayTimeout
           - feign.RetryableException
         ignoreExceptions:
           # common business exception
@@ -118,7 +122,9 @@ resilience4j:
         exponentialBackoffMultiplier: 2.0
         retryExceptions:
           - java.net.SocketTimeoutException
-          - org.springframework.web.client.HttpServerErrorException
+          - feign.FeignException.InternalServerError
+          - feign.FeignException.ServiceUnavailable
+          - feign.FeignException.GatewayTimeout
           - feign.RetryableException
         ignoreExceptions:
           # common business exception

--- a/src/test/java/com/goggles/orderservice/application/OrderCommandServiceTest.java
+++ b/src/test/java/com/goggles/orderservice/application/OrderCommandServiceTest.java
@@ -8,6 +8,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.mock;
 
+import com.goggles.orderservice.application.common.UserRole;
 import com.goggles.orderservice.application.dto.command.CreateLectureOrderCommand;
 import com.goggles.orderservice.application.dto.command.CreateMentoringOrderCommand;
 import com.goggles.orderservice.application.dto.external.ProductReserveInfo;
@@ -77,7 +78,7 @@ class OrderCommandServiceTest {
 
     private CreateLectureOrderCommand command() {
       return new CreateLectureOrderCommand(
-          USER_ID, USER_ROLE, COUPON_ID, "CARD", List.of(LECTURE_ID));
+          USER_ID, UserRole.from(USER_ROLE), COUPON_ID, "CARD", List.of(LECTURE_ID));
     }
 
     @Test
@@ -165,7 +166,7 @@ class OrderCommandServiceTest {
     private CreateMentoringOrderCommand command() {
       return new CreateMentoringOrderCommand(
           USER_ID,
-          USER_ROLE,
+          UserRole.from(USER_ROLE),
           MENTORING_ID,
           "질문 있어요",
           COUPON_ID,


### PR DESCRIPTION
### 📌 관련 이슈
- close #13 

### 💡 작업 내용
- 주문 생성 시 외부 API 장애 대응을 위해 Resilience4j 및 보상 트랜잭션 적용
- 읽기/쓰기/실패 상황에 따라 CircuitBreaker, Retry 설정 분리
- 실패 처리 방식 구분
  - 사용자 응답용 Failback (즉시 실패 응답)
  - 내부 재처리를 위한 상세 로그 기록
- 예외를 재시도 대상 / 무시 대상으로 분리하여 처리
- 주문 도메인에 취소 관련 필드 추가
- (취소 원인, 사유, 취소 시점)


### 🔍 변경 이유
- 외부 서비스(사용자/강의/멘토링) 호출 실패 시, 주문 상태 불일치 및 데이터 정합성 문제를 방지하고 
안정적인 복구 처리를 가능하게 하기 위함

### 📝 리뷰 포인트 (선택)
- 외부 API 호출 실패 시 fallback 및 retry 전략이 적절한지
- 주문 실패 후 강의/멘토링 보상 트랜잭션 흐름이 올바른지
- 예외 분리 기준(재시도/무시)이 적절한지
- DDD 관점에서 도메인 책임이 명확히 분리되었는지
- 내부 API 요청/응답 스펙 일관성 유지 여부

### 🧠 기타 참고 사항
- 주문 취소 로직 구현 이후 재시도 실패 처리에 대한 DLQ를 구현할 예정입니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **새로운 기능**
  * 주문 취소 기록 확장: 취소 사유·설명·취소 시각 저장 및 주문 상세에 노출
  * 강의·멘토링 예약 취소 요청 추가 및 취소 요청 DTO 도입

* **개선 사항**
  * 외부 호출 안정성 강화: 회로 차단기 및 재시도 적용, 실패 시 보상(예약 취소) 자동 시도 및 로깅
  * 초기 데이터 시드 확장: 결제 실패 상태·취소 필드 및 임의 생성일자 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->