### PR TITLE
[feat] 주문 생성 이벤트 구현

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,5 +21,41 @@ services:
       start_period: 30s
     restart: unless-stopped
 
+  kafka:
+    image: confluentinc/cp-kafka:7.6.0
+    container_name: goggles-kafka
+    ports:
+      - "9092:9092"
+      - "9094:9094"
+    environment:
+      KAFKA_NODE_ID: 1
+      KAFKA_PROCESS_ROLES: 'broker,controller'
+      KAFKA_CONTROLLER_QUORUM_VOTERS: '1@kafka:9093'
+      KAFKA_CONTROLLER_LISTENER_NAMES: 'CONTROLLER'
+      KAFKA_LISTENERS: 'PLAINTEXT://:9092,EXTERNAL://:9094,CONTROLLER://:9093'  # ✅
+      KAFKA_ADVERTISED_LISTENERS: 'PLAINTEXT://kafka:9092,EXTERNAL://localhost:9094'  # ✅
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: 'CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,EXTERNAL:PLAINTEXT'  # ✅
+      KAFKA_INTER_BROKER_LISTENER_NAME: 'PLAINTEXT'
+      CLUSTER_ID: 'VUJ0xmn5Suqnyj03q7lD4Q'
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+    volumes:
+      - kafka-data:/var/lib/kafka/data
+    restart: unless-stopped
+
+  kafdrop:
+    image: obsidiandynamics/kafdrop
+    container_name: goggles-kafdrop
+    ports:
+      - "9000:9000"
+    environment:
+      KAFKA_BROKERCONNECT: "kafka:9092"
+    depends_on:
+      - kafka
+    restart: unless-stopped
+
 volumes:
   postgres-data:
+  kafka-data:

--- a/http/http-client.env.json
+++ b/http/http-client.env.json
@@ -1,8 +1,8 @@
 {
   "local": {
-    "host": "localhost:9007",
-    "userId": "b114605e-4c14-4593-ae25-d2e869066a25",
+    "host": "localhost:8080",
+    "userId": "550e8400-e29b-41d4-a716-446655440000",
     "userRole": "STUDENT",
-    "orderId": "95e903be-91b7-4c55-9910-c271c2e964b0"
+    "orderId": "7f658dda-1a73-49aa-a207-e2c1fc75a37d"
   }
 }

--- a/http/init.sql
+++ b/http/init.sql
@@ -168,7 +168,7 @@ INSERT INTO order_db.p_order_item (
     id, order_id, product_id,
     instructor_id, instructor_name,
     product_name, product_price,
-    product_type, status,
+    product_type, status, enrollment_id,
     created_at, updated_at,
     created_by, updated_by
 ) VALUES (
@@ -184,6 +184,7 @@ INSERT INTO order_db.p_order_item (
                  WHEN v_status IN ('CANCELED','PAYMENT_FAILED') THEN 'CANCELED'
                  ELSE 'ACTIVE'
                  END,
+             gen_random_uuid(),
              v_created_at,
              v_created_at,
              user_ids[v_user_idx],

--- a/http/init.sql
+++ b/http/init.sql
@@ -12,6 +12,10 @@ user_ids uuid[] := ARRAY[
         '신혜원', '이호영', '김시온', '한소연', '하지혜'
     ];
 
+    user_emails varchar[] := ARRAY[
+        '신혜원@email.com', '이호영@email.com', '김시온@email.com', '한소연@email.com', '하지혜@email.com'
+    ];
+
     instructors varchar[] := ARRAY[
         '김개발', '박강사', '이튜터', '최멘토', '정코치'
     ];
@@ -111,7 +115,7 @@ END;
 END IF;
 
 INSERT INTO order_db.p_order (
-    id, student_id, student_name,
+    id, student_id, student_name, student_email,
     original_price, discount_amount, final_price,
     status, created_at, updated_at,
     canceled_at, cancel_reason, cancel_description,
@@ -122,6 +126,7 @@ INSERT INTO order_db.p_order (
              v_order_id,
              user_ids[v_user_idx],
              user_names[v_user_idx],
+            user_emails[v_user_idx],
              v_total_price,
              v_discount,
              v_total_price - v_discount,

--- a/http/order.http
+++ b/http/order.http
@@ -8,21 +8,17 @@ Content-Type: application/json
   "couponId": null,
   "paymentMethod": "TOSS",
   "items": [
-    "0397b323-ad12-4536-b3a3-aa68a2f0e036"
+    "c6198b69-015d-477c-a2f4-35c54c777121"
   ]
 }
 
 > {%
   client.test("강의 주문 생성 성공", function() {
     client.assert(response.status === 201, "응답 코드가 201이어야 합니다.");
-    client.assert(
-        response.body.data.studentId === client.global.get("userId"),
-        "주문자 아이디는 요청과 동일해야 합니다."
-    );
   });
 %}
 
-### 1-1.주문 목록 전체 조회 (기본 페이징)
+### 2-1.주문 목록 전체 조회 (기본 페이징)
 GET http://{{host}}/api/v1/orders?page=0&size=10
 X-User-Id: {{userId}}
 
@@ -32,7 +28,7 @@ X-User-Id: {{userId}}
   });
 %}
 
-### 1-2. 주문 목록 조회 (가격 높은 순 정렬)
+### 2-2. 주문 목록 조회 (가격 높은 순 정렬)
 # OrderSortType.PRICE_DESC ("price,desc") 적용
 GET http://{{host}}/api/v1/orders?page=0&size=10&sort=price,desc
 X-User-Id: {{userId}}
@@ -43,7 +39,7 @@ X-User-Id: {{userId}}
   });
 %}
 
-### 1-3. 주문 목록 조회 (상태 필터링: 결제 완료 건만)
+### 2-3. 주문 목록 조회 (상태 필터링: 결제 완료 건만)
 # OrderStatus.PAID ("PAID") 적용
 GET http://{{host}}/api/v1/orders?page=0&size=10&orderStatus=PAID
 X-User-Id: {{userId}}
@@ -54,7 +50,7 @@ X-User-Id: {{userId}}
   });
 %}
 
-### 1-4. 주문 목록 조회 (정렬 + 상태 필터링 복합)
+### 2-4. 주문 목록 조회 (정렬 + 상태 필터링 복합)
 GET http://{{host}}/api/v1/orders?page=0&size=10&sort=createdAt,asc&orderStatus=COMPLETED
 X-User-Id: {{userId}}
 
@@ -65,6 +61,6 @@ X-User-Id: {{userId}}
 %}
 
 
-### 2. 주문 상세 조회
+### 3. 주문 상세 조회
 GET http://{{host}}/api/v1/orders/{{orderId}}
 X-User-Id: {{userId}}

--- a/src/main/java/com/goggles/orderservice/OrderServiceApplication.java
+++ b/src/main/java/com/goggles/orderservice/OrderServiceApplication.java
@@ -10,14 +10,8 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 @SpringBootApplication
 @EnableFeignClients
 @EnableJpaAuditing(auditorAwareRef = "auditorAwareImpl")
-@EntityScan(basePackages = {
-    "com.goggles.orderservice",
-    "com.goggles.common"
-})
-@EnableJpaRepositories(basePackages = {
-    "com.goggles.orderservice",
-    "com.goggles.common"
-})
+@EntityScan(basePackages = {"com.goggles.orderservice", "com.goggles.common"})
+@EnableJpaRepositories(basePackages = {"com.goggles.orderservice", "com.goggles.common"})
 public class OrderServiceApplication {
 
   public static void main(String[] args) {

--- a/src/main/java/com/goggles/orderservice/OrderServiceApplication.java
+++ b/src/main/java/com/goggles/orderservice/OrderServiceApplication.java
@@ -2,12 +2,22 @@ package com.goggles.orderservice;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
 @SpringBootApplication
 @EnableFeignClients
 @EnableJpaAuditing(auditorAwareRef = "auditorAwareImpl")
+@EntityScan(basePackages = {
+    "com.goggles.orderservice",
+    "com.goggles.common"
+})
+@EnableJpaRepositories(basePackages = {
+    "com.goggles.orderservice",
+    "com.goggles.common"
+})
 public class OrderServiceApplication {
 
   public static void main(String[] args) {

--- a/src/main/java/com/goggles/orderservice/application/dto/external/ProductReserveInfo.java
+++ b/src/main/java/com/goggles/orderservice/application/dto/external/ProductReserveInfo.java
@@ -18,7 +18,6 @@ public record ProductReserveInfo(
     return new OrderItemSpec(
         new Product(productId(), productName(), productPrice(), type),
         new Instructor(instructorId(), instructorName()),
-        enrollmentId
-    );
+        enrollmentId);
   }
 }

--- a/src/main/java/com/goggles/orderservice/application/dto/external/ProductReserveInfo.java
+++ b/src/main/java/com/goggles/orderservice/application/dto/external/ProductReserveInfo.java
@@ -17,6 +17,8 @@ public record ProductReserveInfo(
   public OrderItemSpec toOrderItemSpec(OrderItemType type) {
     return new OrderItemSpec(
         new Product(productId(), productName(), productPrice(), type),
-        new Instructor(instructorId(), instructorName()));
+        new Instructor(instructorId(), instructorName()),
+        enrollmentId
+    );
   }
 }

--- a/src/main/java/com/goggles/orderservice/application/dto/external/UserInfo.java
+++ b/src/main/java/com/goggles/orderservice/application/dto/external/UserInfo.java
@@ -2,4 +2,4 @@ package com.goggles.orderservice.application.dto.external;
 
 import java.util.UUID;
 
-public record UserInfo(UUID userId, String userName) {}
+public record UserInfo(UUID userId, String userName, String userEmail) {}

--- a/src/main/java/com/goggles/orderservice/application/dto/result/OrderItemSummary.java
+++ b/src/main/java/com/goggles/orderservice/application/dto/result/OrderItemSummary.java
@@ -7,9 +7,9 @@ import com.goggles.orderservice.domain.model.Product;
 import java.util.UUID;
 
 public record OrderItemSummary(
-    UUID orderItemId, Product product, Instructor instructor, OrderItemStatus status) {
+    UUID orderItemId, Product product, Instructor instructor, OrderItemStatus status, UUID enrollmentId) {
   public static OrderItemSummary from(OrderItem item) {
     return new OrderItemSummary(
-        item.getId(), item.getProduct(), item.getInstructor(), item.getStatus());
+        item.getId(), item.getProduct(), item.getInstructor(), item.getStatus(), item.getEnrollmentId());
   }
 }

--- a/src/main/java/com/goggles/orderservice/application/dto/result/OrderItemSummary.java
+++ b/src/main/java/com/goggles/orderservice/application/dto/result/OrderItemSummary.java
@@ -7,9 +7,17 @@ import com.goggles.orderservice.domain.model.Product;
 import java.util.UUID;
 
 public record OrderItemSummary(
-    UUID orderItemId, Product product, Instructor instructor, OrderItemStatus status, UUID enrollmentId) {
+    UUID orderItemId,
+    Product product,
+    Instructor instructor,
+    OrderItemStatus status,
+    UUID enrollmentId) {
   public static OrderItemSummary from(OrderItem item) {
     return new OrderItemSummary(
-        item.getId(), item.getProduct(), item.getInstructor(), item.getStatus(), item.getEnrollmentId());
+        item.getId(),
+        item.getProduct(),
+        item.getInstructor(),
+        item.getStatus(),
+        item.getEnrollmentId());
   }
 }

--- a/src/main/java/com/goggles/orderservice/application/service/impl/OrderCommandServiceImpl.java
+++ b/src/main/java/com/goggles/orderservice/application/service/impl/OrderCommandServiceImpl.java
@@ -14,6 +14,7 @@ import com.goggles.orderservice.application.port.out.LectureProvider;
 import com.goggles.orderservice.application.port.out.MentoringProvider;
 import com.goggles.orderservice.application.port.out.UserReader;
 import com.goggles.orderservice.application.service.OrderCommandService;
+import com.goggles.orderservice.domain.event.OrderEvents;
 import com.goggles.orderservice.domain.model.CancelReason;
 import com.goggles.orderservice.domain.model.Order;
 import com.goggles.orderservice.domain.model.OrderItemSpec;
@@ -36,6 +37,7 @@ public class OrderCommandServiceImpl implements OrderCommandService {
   private final MentoringProvider mentoringProvider;
   private final UserReader userReader;
   private final OrderRepository orderRepository;
+  private final OrderEvents orderEvents;
 
   @Override
   @Transactional
@@ -48,10 +50,11 @@ public class OrderCommandServiceImpl implements OrderCommandService {
     try {
       Order order =
           Order.create(
-              new Orderer(userInfo.userId(), userInfo.userName()),
+              new Orderer(userInfo.userId(), userInfo.userName(), userInfo.userEmail()),
               null,
               new OrderPrice(totalPrice, 0L),
-              itemSpecs);
+              itemSpecs,
+              orderEvents);
 
       order = orderRepository.createOrder(order);
       return CreateOrderResult.from(order);
@@ -77,10 +80,11 @@ public class OrderCommandServiceImpl implements OrderCommandService {
     try {
       Order order =
           Order.create(
-              new Orderer(userInfo.userId(), userInfo.userName()),
+              new Orderer(userInfo.userId(), userInfo.userName(), userInfo.userEmail()),
               null,
               new OrderPrice(productInfo.productPrice(), 0L),
-              itemSpec);
+              itemSpec,
+              orderEvents);
 
       order = orderRepository.createOrder(order);
       return CreateOrderResult.from(order);

--- a/src/main/java/com/goggles/orderservice/domain/event/LectureOrderCompletionEvent.java
+++ b/src/main/java/com/goggles/orderservice/domain/event/LectureOrderCompletionEvent.java
@@ -3,5 +3,4 @@ package com.goggles.orderservice.domain.event;
 import java.util.List;
 import java.util.UUID;
 
-public record LectureOrderCompletionEvent(UUID orderId, UUID userId, List<UUID> enrollmentIds) {
-}
+public record LectureOrderCompletionEvent(UUID orderId, UUID userId, List<UUID> enrollmentIds) {}

--- a/src/main/java/com/goggles/orderservice/domain/event/LectureOrderCompletionEvent.java
+++ b/src/main/java/com/goggles/orderservice/domain/event/LectureOrderCompletionEvent.java
@@ -1,0 +1,7 @@
+package com.goggles.orderservice.domain.event;
+
+import java.util.List;
+import java.util.UUID;
+
+public record LectureOrderCompletionEvent(UUID orderId, UUID userId, List<UUID> enrollmentIds) {
+}

--- a/src/main/java/com/goggles/orderservice/domain/event/MentoringOrderCompletionEvent.java
+++ b/src/main/java/com/goggles/orderservice/domain/event/MentoringOrderCompletionEvent.java
@@ -1,0 +1,7 @@
+package com.goggles.orderservice.domain.event;
+
+import java.util.UUID;
+
+public record MentoringOrderCompletionEvent(UUID orderId, UUID userId, UUID enrollmentId) {
+
+}

--- a/src/main/java/com/goggles/orderservice/domain/event/MentoringOrderCompletionEvent.java
+++ b/src/main/java/com/goggles/orderservice/domain/event/MentoringOrderCompletionEvent.java
@@ -2,6 +2,4 @@ package com.goggles.orderservice.domain.event;
 
 import java.util.UUID;
 
-public record MentoringOrderCompletionEvent(UUID orderId, UUID userId, UUID enrollmentId) {
-
-}
+public record MentoringOrderCompletionEvent(UUID orderId, UUID userId, UUID enrollmentId) {}

--- a/src/main/java/com/goggles/orderservice/domain/event/OrderEvents.java
+++ b/src/main/java/com/goggles/orderservice/domain/event/OrderEvents.java
@@ -2,4 +2,6 @@ package com.goggles.orderservice.domain.event;
 
 public interface OrderEvents {
   void orderPaymentPending(OrderPaymentPendingEvent event);
+  void lectureOrderCompleted(LectureOrderCompletionEvent event);
+  void mentoringOrderCompleted(MentoringOrderCompletionEvent event);
 }

--- a/src/main/java/com/goggles/orderservice/domain/event/OrderEvents.java
+++ b/src/main/java/com/goggles/orderservice/domain/event/OrderEvents.java
@@ -2,6 +2,8 @@ package com.goggles.orderservice.domain.event;
 
 public interface OrderEvents {
   void orderPaymentPending(OrderPaymentPendingEvent event);
+
   void lectureOrderCompleted(LectureOrderCompletionEvent event);
+
   void mentoringOrderCompleted(MentoringOrderCompletionEvent event);
 }

--- a/src/main/java/com/goggles/orderservice/domain/event/OrderEvents.java
+++ b/src/main/java/com/goggles/orderservice/domain/event/OrderEvents.java
@@ -1,0 +1,5 @@
+package com.goggles.orderservice.domain.event;
+
+public interface OrderEvents {
+  void orderPaymentPending(OrderPaymentPendingEvent event);
+}

--- a/src/main/java/com/goggles/orderservice/domain/event/OrderPaymentPendingEvent.java
+++ b/src/main/java/com/goggles/orderservice/domain/event/OrderPaymentPendingEvent.java
@@ -1,0 +1,33 @@
+package com.goggles.orderservice.domain.event;
+
+import com.goggles.orderservice.domain.model.Order;
+import java.util.UUID;
+
+public record OrderPaymentPendingEvent(
+    UUID orderId,
+    Long amount,
+    UUID customerId,
+    String customerName,
+    String customerEmail,
+    String orderName
+) {
+  public static OrderPaymentPendingEvent from(Order order) {
+    String buildOrderName;
+    if (order.getItems().size() > 1){
+      buildOrderName =
+          order.getItems().getFirst().getProduct().getProductName() + "외 " +
+              (order.getItems().size() - 1) + "건";
+    } else {
+      buildOrderName =
+          order.getItems().getFirst().getProduct().getProductName();
+    }
+    return new OrderPaymentPendingEvent(
+        order.getId(),
+        order.getPrice().getFinalPrice(),
+        order.getOrderer().getStudentId(),
+        order.getOrderer().getStudentName(),
+        order.getOrderer().getStudentEmail(),
+        buildOrderName
+    );
+  }
+}

--- a/src/main/java/com/goggles/orderservice/domain/event/OrderPaymentPendingEvent.java
+++ b/src/main/java/com/goggles/orderservice/domain/event/OrderPaymentPendingEvent.java
@@ -9,17 +9,17 @@ public record OrderPaymentPendingEvent(
     UUID customerId,
     String customerName,
     String customerEmail,
-    String orderName
-) {
+    String orderName) {
   public static OrderPaymentPendingEvent from(Order order) {
     String buildOrderName;
-    if (order.getItems().size() > 1){
+    if (order.getItems().size() > 1) {
       buildOrderName =
-          order.getItems().getFirst().getProduct().getProductName() + "외 " +
-              (order.getItems().size() - 1) + "건";
+          order.getItems().getFirst().getProduct().getProductName()
+              + "외 "
+              + (order.getItems().size() - 1)
+              + "건";
     } else {
-      buildOrderName =
-          order.getItems().getFirst().getProduct().getProductName();
+      buildOrderName = order.getItems().getFirst().getProduct().getProductName();
     }
     return new OrderPaymentPendingEvent(
         order.getId(),
@@ -27,7 +27,6 @@ public record OrderPaymentPendingEvent(
         order.getOrderer().getStudentId(),
         order.getOrderer().getStudentName(),
         order.getOrderer().getStudentEmail(),
-        buildOrderName
-    );
+        buildOrderName);
   }
 }

--- a/src/main/java/com/goggles/orderservice/domain/exception/OrderErrorCode.java
+++ b/src/main/java/com/goggles/orderservice/domain/exception/OrderErrorCode.java
@@ -11,7 +11,12 @@ public enum OrderErrorCode {
   EMPTY_ORDER_ITEMS("주문 상품은 최소 1개 이상이어야 합니다."),
   NULL_ORDER_ITEM("주문 상품에 null 값이 포함될 수 없습니다."),
   ALREADY_ASSIGNED_ORDER("이미 주문에 속한 상품입니다."),
-  ALREADY_CANCELED_ORDER_ITEM("이미 취소된 주문 상품입니다.");
+  ALREADY_CANCELED_ORDER_ITEM("이미 취소된 주문 상품입니다."),
+
+  // Order
+  MISSING_ORDER_ORDERER("주문자 정보는 필수입니다."),
+  MISSING_ORDER_ORDER_PRICE("주문 가격은 필수입니다."),
+  MISSING_ORDER_ORDER_EVENTS("주문 이벤트는 필수입니다.");
 
   private final String messageTemplate;
 

--- a/src/main/java/com/goggles/orderservice/domain/exception/VoErrorCode.java
+++ b/src/main/java/com/goggles/orderservice/domain/exception/VoErrorCode.java
@@ -15,6 +15,7 @@ public enum VoErrorCode {
   // StudentInfo
   MISSING_STUDENT_ID("studentId 값은 필수입니다."),
   MISSING_STUDENT_NAME("studentName 값은 필수입니다."),
+  MISSING_STUDENT_EMAIL("studentEmail 값은 필수입니다."),
 
   // PaymentInfo
   MISSING_PAYMENT_KEY("paymentKey 값은 필수입니다."),

--- a/src/main/java/com/goggles/orderservice/domain/model/Order.java
+++ b/src/main/java/com/goggles/orderservice/domain/model/Order.java
@@ -84,7 +84,7 @@ public class Order extends BaseAudit {
     order.price = price;
 
     for (OrderItemSpec spec : itemSpecs) {
-      order.addItem(OrderItem.create(spec.product(), spec.instructor()));
+      order.addItem(OrderItem.create(spec.product(), spec.instructor(), spec.enrollmentId()));
     }
     events.orderPaymentPending(OrderPaymentPendingEvent.from(order));
 
@@ -108,7 +108,8 @@ public class Order extends BaseAudit {
     order.orderer = orderer;
     order.coupon = coupon;
     order.price = price;
-    order.addItem(OrderItem.create(itemSpec.product(), itemSpec.instructor()));
+    order.addItem(
+        OrderItem.create(itemSpec.product(), itemSpec.instructor(), itemSpec.enrollmentId()));
     events.orderPaymentPending(OrderPaymentPendingEvent.from(order));
 
     return order;
@@ -120,6 +121,7 @@ public class Order extends BaseAudit {
   }
 
   public void completeMentoring(OrderEvents events) {
+    Objects.requireNonNull(events, OrderErrorCode.MISSING_ORDER_ORDER_EVENTS.getMessage());
     transitionTo(OrderStatus.COMPLETED);
     events.mentoringOrderCompleted(
         new MentoringOrderCompletionEvent(
@@ -127,6 +129,7 @@ public class Order extends BaseAudit {
   }
 
   public void completeLecture(OrderEvents events) {
+    Objects.requireNonNull(events, OrderErrorCode.MISSING_ORDER_ORDER_EVENTS.getMessage());
     transitionTo(OrderStatus.COMPLETED);
     events.lectureOrderCompleted(
         new LectureOrderCompletionEvent(

--- a/src/main/java/com/goggles/orderservice/domain/model/Order.java
+++ b/src/main/java/com/goggles/orderservice/domain/model/Order.java
@@ -123,16 +123,16 @@ public class Order extends BaseAudit {
     transitionTo(OrderStatus.COMPLETED);
     events.mentoringOrderCompleted(
         new MentoringOrderCompletionEvent(
-            this.id, this.orderer.getStudentId(), this.items.getFirst().getEnrollmentId())
-    );
+            this.id, this.orderer.getStudentId(), this.items.getFirst().getEnrollmentId()));
   }
 
   public void completeLecture(OrderEvents events) {
     transitionTo(OrderStatus.COMPLETED);
     events.lectureOrderCompleted(
         new LectureOrderCompletionEvent(
-            this.id, this.orderer.getStudentId(), this.items.stream().map(OrderItem::getEnrollmentId).toList())
-    );
+            this.id,
+            this.orderer.getStudentId(),
+            this.items.stream().map(OrderItem::getEnrollmentId).toList()));
   }
 
   public void failPayment() {

--- a/src/main/java/com/goggles/orderservice/domain/model/Order.java
+++ b/src/main/java/com/goggles/orderservice/domain/model/Order.java
@@ -1,6 +1,8 @@
 package com.goggles.orderservice.domain.model;
 
 import com.goggles.common.domain.BaseAudit;
+import com.goggles.orderservice.domain.event.OrderEvents;
+import com.goggles.orderservice.domain.event.OrderPaymentPendingEvent;
 import com.goggles.orderservice.domain.exception.DuplicateOrderItemException;
 import com.goggles.orderservice.domain.exception.InvalidOrderException;
 import com.goggles.orderservice.domain.exception.NotFoundOrderItemException;
@@ -33,7 +35,7 @@ import org.hibernate.annotations.UuidGenerator;
 @SQLRestriction("deleted_at IS NULL")
 public class Order extends BaseAudit {
 
-  @Id @GeneratedValue @UuidGenerator private UUID id;
+  @Id private UUID id;
 
   @Embedded private Orderer orderer;
 
@@ -66,9 +68,10 @@ public class Order extends BaseAudit {
   }
 
   public static Order create(
-      Orderer orderer, Coupon coupon, OrderPrice price, List<OrderItemSpec> itemSpecs) {
+      Orderer orderer, Coupon coupon, OrderPrice price, List<OrderItemSpec> itemSpecs, OrderEvents events) {
     validateItems(itemSpecs);
     Order order = new Order();
+    order.id = UUID.randomUUID();
     order.orderer = orderer;
     order.coupon = coupon;
     order.price = price;
@@ -76,20 +79,23 @@ public class Order extends BaseAudit {
     for (OrderItemSpec spec : itemSpecs) {
       order.addItem(OrderItem.create(spec.product(), spec.instructor()));
     }
+    events.orderPaymentPending(OrderPaymentPendingEvent.from(order));
 
     return order;
   }
 
   public static Order create(
-      Orderer orderer, Coupon coupon, OrderPrice price, OrderItemSpec itemSpec) {
+      Orderer orderer, Coupon coupon, OrderPrice price, OrderItemSpec itemSpec, OrderEvents events) {
     if (itemSpec == null) {
       throw new InvalidOrderException(OrderErrorCode.EMPTY_ORDER_ITEMS);
     }
     Order order = new Order();
+    order.id = UUID.randomUUID();
     order.orderer = orderer;
     order.coupon = coupon;
     order.price = price;
     order.addItem(OrderItem.create(itemSpec.product(), itemSpec.instructor()));
+    events.orderPaymentPending(OrderPaymentPendingEvent.from(order));
 
     return order;
   }

--- a/src/main/java/com/goggles/orderservice/domain/model/Order.java
+++ b/src/main/java/com/goggles/orderservice/domain/model/Order.java
@@ -1,6 +1,8 @@
 package com.goggles.orderservice.domain.model;
 
 import com.goggles.common.domain.BaseAudit;
+import com.goggles.orderservice.domain.event.LectureOrderCompletionEvent;
+import com.goggles.orderservice.domain.event.MentoringOrderCompletionEvent;
 import com.goggles.orderservice.domain.event.OrderEvents;
 import com.goggles.orderservice.domain.event.OrderPaymentPendingEvent;
 import com.goggles.orderservice.domain.exception.DuplicateOrderItemException;
@@ -71,6 +73,9 @@ public class Order extends BaseAudit {
       OrderPrice price,
       List<OrderItemSpec> itemSpecs,
       OrderEvents events) {
+    Objects.requireNonNull(orderer, OrderErrorCode.MISSING_ORDER_ORDERER.getMessage());
+    Objects.requireNonNull(price, OrderErrorCode.MISSING_ORDER_ORDER_PRICE.getMessage());
+    Objects.requireNonNull(events, OrderErrorCode.MISSING_ORDER_ORDER_EVENTS.getMessage());
     validateItems(itemSpecs);
     Order order = new Order();
     order.id = UUID.randomUUID();
@@ -92,6 +97,9 @@ public class Order extends BaseAudit {
       OrderPrice price,
       OrderItemSpec itemSpec,
       OrderEvents events) {
+    Objects.requireNonNull(orderer, OrderErrorCode.MISSING_ORDER_ORDERER.getMessage());
+    Objects.requireNonNull(price, OrderErrorCode.MISSING_ORDER_ORDER_PRICE.getMessage());
+    Objects.requireNonNull(events, OrderErrorCode.MISSING_ORDER_ORDER_EVENTS.getMessage());
     if (itemSpec == null) {
       throw new InvalidOrderException(OrderErrorCode.EMPTY_ORDER_ITEMS);
     }
@@ -111,8 +119,20 @@ public class Order extends BaseAudit {
     transitionTo(OrderStatus.PAID);
   }
 
-  public void complete() {
+  public void completeMentoring(OrderEvents events) {
     transitionTo(OrderStatus.COMPLETED);
+    events.mentoringOrderCompleted(
+        new MentoringOrderCompletionEvent(
+            this.id, this.orderer.getStudentId(), this.items.getFirst().getEnrollmentId())
+    );
+  }
+
+  public void completeLecture(OrderEvents events) {
+    transitionTo(OrderStatus.COMPLETED);
+    events.lectureOrderCompleted(
+        new LectureOrderCompletionEvent(
+            this.id, this.orderer.getStudentId(), this.items.stream().map(OrderItem::getEnrollmentId).toList())
+    );
   }
 
   public void failPayment() {

--- a/src/main/java/com/goggles/orderservice/domain/model/Order.java
+++ b/src/main/java/com/goggles/orderservice/domain/model/Order.java
@@ -13,7 +13,6 @@ import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
@@ -26,7 +25,6 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLRestriction;
-import org.hibernate.annotations.UuidGenerator;
 
 @Entity
 @Table(name = "p_order")
@@ -68,7 +66,11 @@ public class Order extends BaseAudit {
   }
 
   public static Order create(
-      Orderer orderer, Coupon coupon, OrderPrice price, List<OrderItemSpec> itemSpecs, OrderEvents events) {
+      Orderer orderer,
+      Coupon coupon,
+      OrderPrice price,
+      List<OrderItemSpec> itemSpecs,
+      OrderEvents events) {
     validateItems(itemSpecs);
     Order order = new Order();
     order.id = UUID.randomUUID();
@@ -85,7 +87,11 @@ public class Order extends BaseAudit {
   }
 
   public static Order create(
-      Orderer orderer, Coupon coupon, OrderPrice price, OrderItemSpec itemSpec, OrderEvents events) {
+      Orderer orderer,
+      Coupon coupon,
+      OrderPrice price,
+      OrderItemSpec itemSpec,
+      OrderEvents events) {
     if (itemSpec == null) {
       throw new InvalidOrderException(OrderErrorCode.EMPTY_ORDER_ITEMS);
     }

--- a/src/main/java/com/goggles/orderservice/domain/model/OrderItem.java
+++ b/src/main/java/com/goggles/orderservice/domain/model/OrderItem.java
@@ -38,6 +38,9 @@ public class OrderItem extends BaseAudit {
 
   @Embedded private Instructor instructor;
 
+  @Column(name = "enrollment_id")
+  private UUID enrollmentId;
+
   @Enumerated(EnumType.STRING)
   @Column(name = "status", nullable = false, length = 20)
   private OrderItemStatus status = OrderItemStatus.ACTIVE;

--- a/src/main/java/com/goggles/orderservice/domain/model/OrderItem.java
+++ b/src/main/java/com/goggles/orderservice/domain/model/OrderItem.java
@@ -38,17 +38,18 @@ public class OrderItem extends BaseAudit {
 
   @Embedded private Instructor instructor;
 
-  @Column(name = "enrollment_id")
+  @Column(name = "enrollment_id", nullable = false, updatable = false)
   private UUID enrollmentId;
 
   @Enumerated(EnumType.STRING)
   @Column(name = "status", nullable = false, length = 20)
   private OrderItemStatus status = OrderItemStatus.ACTIVE;
 
-  static OrderItem create(Product product, Instructor instructor) {
+  static OrderItem create(Product product, Instructor instructor, UUID enrollmentId) {
     OrderItem item = new OrderItem();
     item.product = product;
     item.instructor = instructor;
+    item.enrollmentId = enrollmentId;
     return item;
   }
 

--- a/src/main/java/com/goggles/orderservice/domain/model/OrderItemSpec.java
+++ b/src/main/java/com/goggles/orderservice/domain/model/OrderItemSpec.java
@@ -2,10 +2,11 @@ package com.goggles.orderservice.domain.model;
 
 import com.goggles.orderservice.domain.exception.InvalidVoException;
 import com.goggles.orderservice.domain.exception.VoErrorCode;
+import java.util.UUID;
 
-public record OrderItemSpec(Product product, Instructor instructor) {
+public record OrderItemSpec(Product product, Instructor instructor, UUID enrollmentId) {
   public OrderItemSpec {
-    if (product == null || instructor == null) {
+    if (product == null || instructor == null || enrollmentId == null) {
       throw new InvalidVoException(VoErrorCode.NULL_ORDER_ITEM_SPEC);
     }
   }

--- a/src/main/java/com/goggles/orderservice/domain/model/Orderer.java
+++ b/src/main/java/com/goggles/orderservice/domain/model/Orderer.java
@@ -21,19 +21,27 @@ public class Orderer {
   @Column(name = "student_name", nullable = false, length = 20)
   private String studentName;
 
-  public Orderer(UUID studentId, String studentName) {
-    validate(studentId, studentName);
+  @Column(name = "student_email", nullable = false, length = 30)
+  private String studentEmail;
+
+  public Orderer(UUID studentId, String studentName, String studentEmail) {
+    validate(studentId, studentName, studentEmail);
     this.studentId = studentId;
     this.studentName = studentName;
+    this.studentEmail = studentEmail;
   }
 
-  public static void validate(UUID studentId, String studentName) {
+  public static void validate(UUID studentId, String studentName, String studentEmail) {
     if (studentId == null) {
       throw new InvalidVoException(VoErrorCode.MISSING_STUDENT_ID);
     }
 
     if (studentName == null || studentName.isBlank()) {
       throw new InvalidVoException(VoErrorCode.MISSING_STUDENT_NAME);
+    }
+
+    if (studentEmail == null || studentEmail.isBlank()) {
+      throw new InvalidVoException(VoErrorCode.MISSING_STUDENT_EMAIL);
     }
   }
 }

--- a/src/main/java/com/goggles/orderservice/infrastructure/client/LectureClientAdapter.java
+++ b/src/main/java/com/goggles/orderservice/infrastructure/client/LectureClientAdapter.java
@@ -38,7 +38,7 @@ public class LectureClientAdapter implements LectureProvider {
   private List<ProductReserveInfo> reserveEnrollmentFallback(
       LectureProductReserveData data, Throwable t) {
     log.warn("lecture-service fallback. cause: {}", t.getMessage());
-    log.warn("lecture-service fallback. exception type: {}", t.getClass().getName()); // ← 추가
+    log.warn("lecture-service fallback. exception type: {}", t.getClass().getName());
     log.warn("lecture-service fallback. stacktrace: ", t);
 
     if (t instanceof CallNotPermittedException) {

--- a/src/main/java/com/goggles/orderservice/infrastructure/client/MentoringClientAdapter.java
+++ b/src/main/java/com/goggles/orderservice/infrastructure/client/MentoringClientAdapter.java
@@ -40,7 +40,7 @@ public class MentoringClientAdapter implements MentoringProvider {
   private ProductReserveInfo reserveEnrollmentFallback(
       MentoringProductReserveData data, Throwable t) {
     log.warn("mentoring-service fallback. cause: {}", t.getMessage());
-    log.warn("mentoring-service fallback. exception type: {}", t.getClass().getName()); // ← 추가
+    log.warn("mentoring-service fallback. exception type: {}", t.getClass().getName());
     log.warn("mentoring-service fallback. stacktrace: ", t);
 
     if (t instanceof CallNotPermittedException) {

--- a/src/main/java/com/goggles/orderservice/infrastructure/client/dto/GetUserInfoResponse.java
+++ b/src/main/java/com/goggles/orderservice/infrastructure/client/dto/GetUserInfoResponse.java
@@ -3,8 +3,8 @@ package com.goggles.orderservice.infrastructure.client.dto;
 import com.goggles.orderservice.application.dto.external.UserInfo;
 import java.util.UUID;
 
-public record GetUserInfoResponse(UUID userId, String userName) {
+public record GetUserInfoResponse(UUID userId, String userName, String userEmail) {
   public UserInfo toUserInfo() {
-    return new UserInfo(userId, userName);
+    return new UserInfo(userId, userName, userEmail);
   }
 }

--- a/src/main/java/com/goggles/orderservice/infrastructure/config/OutboxConfiguration.java
+++ b/src/main/java/com/goggles/orderservice/infrastructure/config/OutboxConfiguration.java
@@ -15,22 +15,26 @@ import org.springframework.kafka.core.KafkaTemplate;
 public class OutboxConfiguration {
 
   @Bean
-  public OutboxStatusUpdater outboxStatusUpdater(OutboxRepository outboxRepository,
-      KafkaTemplate<String, Object> kafkaTemplate) {
+  public OutboxStatusUpdater outboxStatusUpdater(
+      OutboxRepository outboxRepository, KafkaTemplate<String, Object> kafkaTemplate) {
     return new OutboxStatusUpdater(outboxRepository, kafkaTemplate);
   }
 
   @Bean
-  public OutboxEventListener outboxEventListener(OutboxRepository outboxRepository,
-      KafkaTemplate<String, Object> kafkaTemplate, ObjectMapper objectMapper,
+  public OutboxEventListener outboxEventListener(
+      OutboxRepository outboxRepository,
+      KafkaTemplate<String, Object> kafkaTemplate,
+      ObjectMapper objectMapper,
       OutboxStatusUpdater outboxStatusUpdater) {
-    return new OutboxEventListener(outboxRepository, kafkaTemplate, objectMapper,
-        outboxStatusUpdater);
+    return new OutboxEventListener(
+        outboxRepository, kafkaTemplate, objectMapper, outboxStatusUpdater);
   }
 
   @Bean
-  public OutboxRelayScheduler outboxRelayScheduler(OutboxRepository outboxRepository,
-      KafkaTemplate<String, Object> kafkaTemplate, OutboxStatusUpdater outboxStatusUpdater) {
+  public OutboxRelayScheduler outboxRelayScheduler(
+      OutboxRepository outboxRepository,
+      KafkaTemplate<String, Object> kafkaTemplate,
+      OutboxStatusUpdater outboxStatusUpdater) {
     return new OutboxRelayScheduler(outboxRepository, kafkaTemplate, outboxStatusUpdater);
   }
 }

--- a/src/main/java/com/goggles/orderservice/infrastructure/config/OutboxConfiguration.java
+++ b/src/main/java/com/goggles/orderservice/infrastructure/config/OutboxConfiguration.java
@@ -1,0 +1,36 @@
+package com.goggles.orderservice.infrastructure.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.goggles.common.domain.OutboxRepository;
+import com.goggles.common.event.OutboxEventListener;
+import com.goggles.common.event.OutboxStatusUpdater;
+import com.goggles.common.event.scheduler.OutboxRelayScheduler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.KafkaTemplate;
+
+@Configuration
+@RequiredArgsConstructor
+public class OutboxConfiguration {
+
+  @Bean
+  public OutboxStatusUpdater outboxStatusUpdater(OutboxRepository outboxRepository,
+      KafkaTemplate<String, Object> kafkaTemplate) {
+    return new OutboxStatusUpdater(outboxRepository, kafkaTemplate);
+  }
+
+  @Bean
+  public OutboxEventListener outboxEventListener(OutboxRepository outboxRepository,
+      KafkaTemplate<String, Object> kafkaTemplate, ObjectMapper objectMapper,
+      OutboxStatusUpdater outboxStatusUpdater) {
+    return new OutboxEventListener(outboxRepository, kafkaTemplate, objectMapper,
+        outboxStatusUpdater);
+  }
+
+  @Bean
+  public OutboxRelayScheduler outboxRelayScheduler(OutboxRepository outboxRepository,
+      KafkaTemplate<String, Object> kafkaTemplate, OutboxStatusUpdater outboxStatusUpdater) {
+    return new OutboxRelayScheduler(outboxRepository, kafkaTemplate, outboxStatusUpdater);
+  }
+}

--- a/src/main/java/com/goggles/orderservice/infrastructure/event/OrderEventsImpl.java
+++ b/src/main/java/com/goggles/orderservice/infrastructure/event/OrderEventsImpl.java
@@ -1,0 +1,32 @@
+package com.goggles.orderservice.infrastructure.event;
+
+import com.goggles.common.event.Events;
+import com.goggles.orderservice.domain.event.OrderEvents;
+import com.goggles.orderservice.domain.event.OrderPaymentPendingEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@EnableConfigurationProperties(OrderTopics.class)
+public class OrderEventsImpl implements OrderEvents {
+
+  private final OrderTopics orderTopics;
+  private final Events events;
+
+  public static final String DOMAIN = "ORDER";
+
+  @Override
+  public void orderPaymentPending(OrderPaymentPendingEvent event) {
+    log.info("[OrderEvents] orderPaymentPending 호출 - orderId: {}", event.orderId());
+    events.trigger(
+        event.orderId().toString(),
+        DOMAIN,
+        orderTopics.paymentPending(),
+        event
+    );
+  }
+}

--- a/src/main/java/com/goggles/orderservice/infrastructure/event/OrderEventsImpl.java
+++ b/src/main/java/com/goggles/orderservice/infrastructure/event/OrderEventsImpl.java
@@ -1,6 +1,8 @@
 package com.goggles.orderservice.infrastructure.event;
 
 import com.goggles.common.event.Events;
+import com.goggles.orderservice.domain.event.LectureOrderCompletionEvent;
+import com.goggles.orderservice.domain.event.MentoringOrderCompletionEvent;
 import com.goggles.orderservice.domain.event.OrderEvents;
 import com.goggles.orderservice.domain.event.OrderPaymentPendingEvent;
 import lombok.RequiredArgsConstructor;
@@ -21,7 +23,16 @@ public class OrderEventsImpl implements OrderEvents {
 
   @Override
   public void orderPaymentPending(OrderPaymentPendingEvent event) {
-    log.info("[OrderEvents] orderPaymentPending 호출 - orderId: {}", event.orderId());
     events.trigger(event.orderId().toString(), DOMAIN, orderTopics.paymentPending(), event);
+  }
+
+  @Override
+  public void lectureOrderCompleted(LectureOrderCompletionEvent event) {
+    events.trigger(event.orderId().toString(), DOMAIN, orderTopics.completed(), event);
+  }
+
+  @Override
+  public void mentoringOrderCompleted(MentoringOrderCompletionEvent event) {
+    events.trigger(event.orderId().toString(), DOMAIN, orderTopics.completed(), event);
   }
 }

--- a/src/main/java/com/goggles/orderservice/infrastructure/event/OrderEventsImpl.java
+++ b/src/main/java/com/goggles/orderservice/infrastructure/event/OrderEventsImpl.java
@@ -22,11 +22,6 @@ public class OrderEventsImpl implements OrderEvents {
   @Override
   public void orderPaymentPending(OrderPaymentPendingEvent event) {
     log.info("[OrderEvents] orderPaymentPending 호출 - orderId: {}", event.orderId());
-    events.trigger(
-        event.orderId().toString(),
-        DOMAIN,
-        orderTopics.paymentPending(),
-        event
-    );
+    events.trigger(event.orderId().toString(), DOMAIN, orderTopics.paymentPending(), event);
   }
 }

--- a/src/main/java/com/goggles/orderservice/infrastructure/event/OrderTopics.java
+++ b/src/main/java/com/goggles/orderservice/infrastructure/event/OrderTopics.java
@@ -1,0 +1,9 @@
+package com.goggles.orderservice.infrastructure.event;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "topics.order")
+public record OrderTopics(
+    String paymentPending,
+    String cancelled
+) {}

--- a/src/main/java/com/goggles/orderservice/infrastructure/event/OrderTopics.java
+++ b/src/main/java/com/goggles/orderservice/infrastructure/event/OrderTopics.java
@@ -3,7 +3,4 @@ package com.goggles.orderservice.infrastructure.event;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix = "topics.order")
-public record OrderTopics(
-    String paymentPending,
-    String cancelled
-) {}
+public record OrderTopics(String paymentPending, String cancelled) {}

--- a/src/main/java/com/goggles/orderservice/infrastructure/event/OrderTopics.java
+++ b/src/main/java/com/goggles/orderservice/infrastructure/event/OrderTopics.java
@@ -3,4 +3,4 @@ package com.goggles.orderservice.infrastructure.event;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix = "topics.order")
-public record OrderTopics(String paymentPending, String cancelled) {}
+public record OrderTopics(String paymentPending, String completed, String cancelled) {}

--- a/src/main/java/com/goggles/orderservice/presentation/dto/OrderItemSummaryResponse.java
+++ b/src/main/java/com/goggles/orderservice/presentation/dto/OrderItemSummaryResponse.java
@@ -11,7 +11,8 @@ public record OrderItemSummaryResponse(
     String productType,
     UUID instructorId,
     String instructorName,
-    String orderItemStatus) {
+    String orderItemStatus,
+    UUID enrollmentId) {
   public static OrderItemSummaryResponse from(OrderItemSummary item) {
     return new OrderItemSummaryResponse(
         item.orderItemId(),
@@ -21,6 +22,7 @@ public record OrderItemSummaryResponse(
         item.product().getProductType().name(),
         item.instructor().getInstructorId(),
         item.instructor().getInstructorName(),
-        item.status().getDisplayName());
+        item.status().getDisplayName(),
+        item.enrollmentId());
   }
 }

--- a/src/test/java/com/goggles/orderservice/application/OrderCommandServiceTest.java
+++ b/src/test/java/com/goggles/orderservice/application/OrderCommandServiceTest.java
@@ -18,6 +18,8 @@ import com.goggles.orderservice.application.port.out.LectureProvider;
 import com.goggles.orderservice.application.port.out.MentoringProvider;
 import com.goggles.orderservice.application.port.out.UserReader;
 import com.goggles.orderservice.application.service.impl.OrderCommandServiceImpl;
+import com.goggles.orderservice.domain.event.OrderEvents;
+import com.goggles.orderservice.domain.event.OrderPaymentPendingEvent;
 import com.goggles.orderservice.domain.model.Order;
 import com.goggles.orderservice.domain.model.Orderer;
 import com.goggles.orderservice.domain.repository.OrderRepository;
@@ -42,6 +44,7 @@ class OrderCommandServiceTest {
   @Mock private MentoringProvider mentoringProvider;
   @Mock private UserReader userReader;
   @Mock private OrderRepository orderRepository;
+  @Mock private OrderEvents orderEvents;
 
   private final UUID USER_ID = UUID.randomUUID();
   private final UUID COUPON_ID = UUID.randomUUID();
@@ -50,9 +53,10 @@ class OrderCommandServiceTest {
   private final UUID ORDER_ID = UUID.randomUUID();
   private final String USER_ROLE = "STUDENT";
   private final String USER_NAME = "홍길동";
+  private final String USER_EMAIL = "hello1@naver.com";
 
   private UserInfo userInfo() {
-    return new UserInfo(USER_ID, USER_NAME);
+    return new UserInfo(USER_ID, USER_NAME, USER_EMAIL);
   }
 
   private ProductReserveInfo lectureProductReserveInfo() {
@@ -68,7 +72,7 @@ class OrderCommandServiceTest {
   private Order mockOrder() {
     Order order = mock(Order.class);
     given(order.getId()).willReturn(ORDER_ID);
-    given(order.getOrderer()).willReturn(new Orderer(USER_ID, USER_NAME));
+    given(order.getOrderer()).willReturn(new Orderer(USER_ID, USER_NAME, USER_EMAIL));
     return order;
   }
 
@@ -102,6 +106,8 @@ class OrderCommandServiceTest {
       then(userReader).should().getUserInfo(USER_ID);
       then(lectureProvider).should().reserveEnrollment(any());
       then(orderRepository).should().createOrder(any());
+
+      then(orderEvents).should().orderPaymentPending(any(OrderPaymentPendingEvent.class));
     }
 
     @Test
@@ -127,6 +133,8 @@ class OrderCommandServiceTest {
       then(orderRepository)
           .should()
           .createOrder(argThat(o -> o.getPrice().getFinalPrice() == 30000L));
+
+      then(orderEvents).should().orderPaymentPending(any(OrderPaymentPendingEvent.class));
     }
 
     @Test
@@ -197,6 +205,8 @@ class OrderCommandServiceTest {
       then(userReader).should().getUserInfo(USER_ID);
       then(mentoringProvider).should().reserveEnrollment(any());
       then(orderRepository).should().createOrder(any());
+
+      then(orderEvents).should().orderPaymentPending(any(OrderPaymentPendingEvent.class));
     }
 
     @Test
@@ -217,6 +227,8 @@ class OrderCommandServiceTest {
       then(orderRepository)
           .should()
           .createOrder(argThat(o -> o.getPrice().getFinalPrice() == 50000L));
+
+      then(orderEvents).should().orderPaymentPending(any(OrderPaymentPendingEvent.class));
     }
 
     @Test

--- a/src/test/java/com/goggles/orderservice/application/OrderQueryServiceTest.java
+++ b/src/test/java/com/goggles/orderservice/application/OrderQueryServiceTest.java
@@ -69,7 +69,8 @@ public class OrderQueryServiceTest {
             List.of(
                 new OrderItemSpec(
                     new Product(UUID.randomUUID(), "자바 강의", 100000L, OrderItemType.LECTURE),
-                    new Instructor(UUID.randomUUID(), "강사명"))),
+                    new Instructor(UUID.randomUUID(), "강사명"),
+                    UUID.randomUUID())),
             orderEvents);
 
     order1 =
@@ -80,10 +81,12 @@ public class OrderQueryServiceTest {
             List.of(
                 new OrderItemSpec(
                     new Product(UUID.randomUUID(), "스프링 강의", 110000L, OrderItemType.LECTURE),
-                    new Instructor(UUID.randomUUID(), "강사명")),
+                    new Instructor(UUID.randomUUID(), "강사명"),
+                    UUID.randomUUID()),
                 new OrderItemSpec(
                     new Product(UUID.randomUUID(), "GITHUB 강의", 580000L, OrderItemType.LECTURE),
-                    new Instructor(UUID.randomUUID(), "강사명"))),
+                    new Instructor(UUID.randomUUID(), "강사명"),
+                    UUID.randomUUID())),
             orderEvents);
 
     ReflectionTestUtils.setField(order, "id", UUID.randomUUID());

--- a/src/test/java/com/goggles/orderservice/application/OrderQueryServiceTest.java
+++ b/src/test/java/com/goggles/orderservice/application/OrderQueryServiceTest.java
@@ -70,8 +70,7 @@ public class OrderQueryServiceTest {
                 new OrderItemSpec(
                     new Product(UUID.randomUUID(), "자바 강의", 100000L, OrderItemType.LECTURE),
                     new Instructor(UUID.randomUUID(), "강사명"))),
-            orderEvents
-        );
+            orderEvents);
 
     order1 =
         Order.create(
@@ -85,8 +84,7 @@ public class OrderQueryServiceTest {
                 new OrderItemSpec(
                     new Product(UUID.randomUUID(), "GITHUB 강의", 580000L, OrderItemType.LECTURE),
                     new Instructor(UUID.randomUUID(), "강사명"))),
-            orderEvents
-        );
+            orderEvents);
 
     ReflectionTestUtils.setField(order, "id", UUID.randomUUID());
     ReflectionTestUtils.setField(order1, "id", UUID.randomUUID());

--- a/src/test/java/com/goggles/orderservice/application/OrderQueryServiceTest.java
+++ b/src/test/java/com/goggles/orderservice/application/OrderQueryServiceTest.java
@@ -15,6 +15,7 @@ import com.goggles.orderservice.application.dto.result.OrderDetailResult;
 import com.goggles.orderservice.application.dto.result.OrderItemSummary;
 import com.goggles.orderservice.application.dto.result.OrderListResult;
 import com.goggles.orderservice.application.service.impl.OrderQueryServiceImpl;
+import com.goggles.orderservice.domain.event.OrderEvents;
 import com.goggles.orderservice.domain.model.Instructor;
 import com.goggles.orderservice.domain.model.Order;
 import com.goggles.orderservice.domain.model.OrderItemSpec;
@@ -49,6 +50,7 @@ public class OrderQueryServiceTest {
   @InjectMocks private OrderQueryServiceImpl orderQueryService;
 
   @Mock private OrderRepository orderRepository;
+  @Mock private OrderEvents orderEvents;
 
   private UUID orderId;
   private UUID userId;
@@ -61,17 +63,19 @@ public class OrderQueryServiceTest {
 
     order =
         Order.create(
-            new Orderer(userId, "신혜원"),
+            new Orderer(userId, "신혜원", "hello2@naver.com"),
             null,
             new OrderPrice(110000L, 15000L),
             List.of(
                 new OrderItemSpec(
                     new Product(UUID.randomUUID(), "자바 강의", 100000L, OrderItemType.LECTURE),
-                    new Instructor(UUID.randomUUID(), "강사명"))));
+                    new Instructor(UUID.randomUUID(), "강사명"))),
+            orderEvents
+        );
 
     order1 =
         Order.create(
-            new Orderer(userId, "신혜원"),
+            new Orderer(userId, "신혜원", "hello2@naver.com"),
             null,
             new OrderPrice(900000L, 5000L),
             List.of(
@@ -80,7 +84,9 @@ public class OrderQueryServiceTest {
                     new Instructor(UUID.randomUUID(), "강사명")),
                 new OrderItemSpec(
                     new Product(UUID.randomUUID(), "GITHUB 강의", 580000L, OrderItemType.LECTURE),
-                    new Instructor(UUID.randomUUID(), "강사명"))));
+                    new Instructor(UUID.randomUUID(), "강사명"))),
+            orderEvents
+        );
 
     ReflectionTestUtils.setField(order, "id", UUID.randomUUID());
     ReflectionTestUtils.setField(order1, "id", UUID.randomUUID());


### PR DESCRIPTION
### 📌 관련 이슈
- close #16 

### 💡 작업 내용
- docker compose에 kafka, kafdrop 이미지 추가
- common 라이브러리 outbox, inbox 엔티티 및 레포지토리 클래스 불러오도록 설정
- OutboxConfiguration 설정 파일 추가
- 주문 생성, 강의/멘토링 주문 완료 이벤트 정의
- 주문 생성 kafka 이벤트 구현
- 주문 상품 엔티티에 등록 ID 필드 추가
- 주문자 VO에 사용자 이메일 필드 추가

### 🔍 변경 이유
- 서비스 간 결합도를 낮추고 비동기 이벤트 기반 구조로 확장하기 위함
- 트랜잭션 내 이벤트 유실 방지를 위해 Outbox 패턴 적용 필요
- 주문 생성 및 완료 시 후속 처리(알림, 통계, 결제 등)를 이벤트로 분리하기 위함
- Kafka 기반 메시징 환경을 로컬에서도 테스트할 수 있도록 구성 필요

### 📝 리뷰 포인트 (선택)
- Outbox 패턴 적용 방식 (트랜잭션 내 저장 → 이벤트 발행 흐름)이 적절한지
- 이벤트 객체 설계 (주문 생성/완료 이벤트)가 확장성을 고려했는지
- Kafka 발행 시점 및 책임 분리가 올바르게 되어 있는지
- common 라이브러리 의존 구조가 적절한지

### 🧠 기타 참고 사항
(참고 문서, 스크린샷 등)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 주문 생성 시 학생 이메일 수집 및 저장 추가
  * 주문 처리 이벤트(결제 대기, 주문 완료) 발행으로 외부 연동 개선
  * 주문 항목에 수강(등록) ID가 포함되어 응답에 노출됨

* **개선 사항**
  * 개발 환경에 메시지 브로커 및 모니터링 UI 추가로 이벤트 기반 처리 지원 강화
  * 주문 생성·완료 흐름의 안정성 및 데이터 무결성 향상
<!-- end of auto-generated comment: release notes by coderabbit.ai -->