### PR TITLE
[feat] 강의/멘토링 주문 취소 구현

### DIFF
--- a/src/main/java/com/goggles/orderservice/application/dto/command/CancelLectureOrderCommand.java
+++ b/src/main/java/com/goggles/orderservice/application/dto/command/CancelLectureOrderCommand.java
@@ -1,0 +1,13 @@
+package com.goggles.orderservice.application.dto.command;
+
+import com.goggles.orderservice.application.common.UserRole;
+import java.util.List;
+import java.util.UUID;
+
+public record CancelLectureOrderCommand(
+    UUID userId,
+    UserRole userRole,
+    UUID orderId,
+    List<UUID> enrollmentIds,
+    String cancelReason,
+    String cancelDescription) {}

--- a/src/main/java/com/goggles/orderservice/application/dto/command/CancelMentoringOrderCommand.java
+++ b/src/main/java/com/goggles/orderservice/application/dto/command/CancelMentoringOrderCommand.java
@@ -1,0 +1,12 @@
+package com.goggles.orderservice.application.dto.command;
+
+import com.goggles.orderservice.application.common.UserRole;
+import java.util.UUID;
+
+public record CancelMentoringOrderCommand(
+    UUID userId,
+    UserRole userRole,
+    UUID orderId,
+    UUID enrollmentId,
+    String cancelReason,
+    String cancelDescription) {}

--- a/src/main/java/com/goggles/orderservice/application/dto/external/CancelLectureEnrollmentData.java
+++ b/src/main/java/com/goggles/orderservice/application/dto/external/CancelLectureEnrollmentData.java
@@ -1,14 +1,24 @@
 package com.goggles.orderservice.application.dto.external;
 
 import com.goggles.orderservice.application.common.UserRole;
-import com.goggles.orderservice.domain.model.CancelReason;
+import com.goggles.orderservice.application.dto.command.CancelLectureOrderCommand;
 import java.util.List;
 import java.util.UUID;
 
 public record CancelLectureEnrollmentData(
-    UUID userId, UserRole userRole, List<UUID> LectureEnrollmentIds, CancelReason cancelReason) {
-  public static CancelLectureEnrollmentData of(
-      UUID userId, UserRole userRole, List<UUID> LectureEnrollmentIds, CancelReason cancelReason) {
-    return new CancelLectureEnrollmentData(userId, userRole, LectureEnrollmentIds, cancelReason);
+    UUID userId,
+    UserRole userRole,
+    UUID orderId,
+    List<UUID> enrollmentIds,
+    String cancelReason,
+    String cancelDescription) {
+  public static CancelLectureEnrollmentData from(CancelLectureOrderCommand command) {
+    return new CancelLectureEnrollmentData(
+        command.userId(),
+        command.userRole(),
+        command.orderId(),
+        command.enrollmentIds(),
+        command.cancelReason(),
+        command.cancelDescription());
   }
 }

--- a/src/main/java/com/goggles/orderservice/application/dto/external/CancelMentoringBookingData.java
+++ b/src/main/java/com/goggles/orderservice/application/dto/external/CancelMentoringBookingData.java
@@ -1,13 +1,23 @@
 package com.goggles.orderservice.application.dto.external;
 
 import com.goggles.orderservice.application.common.UserRole;
-import com.goggles.orderservice.domain.model.CancelReason;
+import com.goggles.orderservice.application.dto.command.CancelMentoringOrderCommand;
 import java.util.UUID;
 
 public record CancelMentoringBookingData(
-    UUID userId, UserRole userRole, UUID mentoringBookingId, CancelReason cancelReason) {
-  public static CancelMentoringBookingData of(
-      UUID userId, UserRole userRole, UUID mentoringBookingId, CancelReason cancelReason) {
-    return new CancelMentoringBookingData(userId, userRole, mentoringBookingId, cancelReason);
+    UUID userId,
+    UserRole userRole,
+    UUID orderId,
+    UUID bookingId,
+    String cancelReason,
+    String cancelDescription) {
+  public static CancelMentoringBookingData from(CancelMentoringOrderCommand command) {
+    return new CancelMentoringBookingData(
+        command.userId(),
+        command.userRole(),
+        command.orderId(),
+        command.enrollmentId(),
+        command.cancelReason(),
+        command.cancelDescription());
   }
 }

--- a/src/main/java/com/goggles/orderservice/application/dto/external/RollbackLectureEnrollmentData.java
+++ b/src/main/java/com/goggles/orderservice/application/dto/external/RollbackLectureEnrollmentData.java
@@ -1,0 +1,8 @@
+package com.goggles.orderservice.application.dto.external;
+
+import com.goggles.orderservice.application.common.UserRole;
+import java.util.List;
+import java.util.UUID;
+
+public record RollbackLectureEnrollmentData(
+    UUID userId, UserRole userRole, List<UUID> enrollmentIds, String cancelReason) {}

--- a/src/main/java/com/goggles/orderservice/application/dto/external/RollbackMentoringBookingData.java
+++ b/src/main/java/com/goggles/orderservice/application/dto/external/RollbackMentoringBookingData.java
@@ -1,0 +1,7 @@
+package com.goggles.orderservice.application.dto.external;
+
+import com.goggles.orderservice.application.common.UserRole;
+import java.util.UUID;
+
+public record RollbackMentoringBookingData(
+    UUID userId, UserRole userRole, UUID bookingId, String cancelReason) {}

--- a/src/main/java/com/goggles/orderservice/application/dto/result/CancelOrderResult.java
+++ b/src/main/java/com/goggles/orderservice/application/dto/result/CancelOrderResult.java
@@ -1,0 +1,10 @@
+package com.goggles.orderservice.application.dto.result;
+
+import com.goggles.orderservice.domain.model.Order;
+import java.util.UUID;
+
+public record CancelOrderResult(UUID orderId, Long refundPrice) {
+  public static CancelOrderResult from(Order order) {
+    return new CancelOrderResult(order.getId(), order.getPrice().getFinalPrice());
+  }
+}

--- a/src/main/java/com/goggles/orderservice/application/dto/result/CreateOrderResult.java
+++ b/src/main/java/com/goggles/orderservice/application/dto/result/CreateOrderResult.java
@@ -3,8 +3,15 @@ package com.goggles.orderservice.application.dto.result;
 import com.goggles.orderservice.domain.model.Order;
 import java.util.UUID;
 
-public record CreateOrderResult(UUID orderId, UUID studentId) {
+public record CreateOrderResult(UUID orderId, String productName, Long orderPrice) {
   public static CreateOrderResult from(Order order) {
-    return new CreateOrderResult(order.getId(), order.getOrderer().getStudentId());
+    return new CreateOrderResult(
+        order.getId(),
+        order.getItems().getFirst().getProduct().getProductName(),
+        order.getPrice().getFinalPrice());
+  }
+
+  public static CreateOrderResult of(Order order, String productName) {
+    return new CreateOrderResult(order.getId(), productName, order.getPrice().getFinalPrice());
   }
 }

--- a/src/main/java/com/goggles/orderservice/application/port/out/LectureProvider.java
+++ b/src/main/java/com/goggles/orderservice/application/port/out/LectureProvider.java
@@ -3,10 +3,13 @@ package com.goggles.orderservice.application.port.out;
 import com.goggles.orderservice.application.dto.external.CancelLectureEnrollmentData;
 import com.goggles.orderservice.application.dto.external.LectureProductReserveData;
 import com.goggles.orderservice.application.dto.external.ProductReserveInfo;
+import com.goggles.orderservice.application.dto.external.RollbackLectureEnrollmentData;
 import java.util.List;
 
 public interface LectureProvider {
   List<ProductReserveInfo> reserveEnrollment(LectureProductReserveData data);
+
+  void rollbackLectureEnrollment(RollbackLectureEnrollmentData data);
 
   void cancelLectureEnrollment(CancelLectureEnrollmentData data);
 }

--- a/src/main/java/com/goggles/orderservice/application/port/out/MentoringProvider.java
+++ b/src/main/java/com/goggles/orderservice/application/port/out/MentoringProvider.java
@@ -3,9 +3,12 @@ package com.goggles.orderservice.application.port.out;
 import com.goggles.orderservice.application.dto.external.CancelMentoringBookingData;
 import com.goggles.orderservice.application.dto.external.MentoringProductReserveData;
 import com.goggles.orderservice.application.dto.external.ProductReserveInfo;
+import com.goggles.orderservice.application.dto.external.RollbackMentoringBookingData;
 
 public interface MentoringProvider {
   ProductReserveInfo reserveEnrollment(MentoringProductReserveData data);
+
+  void rollbackMentoringBooking(RollbackMentoringBookingData data);
 
   void cancelMentoringBooking(CancelMentoringBookingData data);
 }

--- a/src/main/java/com/goggles/orderservice/application/service/OrderCommandService.java
+++ b/src/main/java/com/goggles/orderservice/application/service/OrderCommandService.java
@@ -1,11 +1,18 @@
 package com.goggles.orderservice.application.service;
 
+import com.goggles.orderservice.application.dto.command.CancelLectureOrderCommand;
+import com.goggles.orderservice.application.dto.command.CancelMentoringOrderCommand;
 import com.goggles.orderservice.application.dto.command.CreateLectureOrderCommand;
 import com.goggles.orderservice.application.dto.command.CreateMentoringOrderCommand;
+import com.goggles.orderservice.application.dto.result.CancelOrderResult;
 import com.goggles.orderservice.application.dto.result.CreateOrderResult;
 
 public interface OrderCommandService {
   CreateOrderResult createLectureOrder(CreateLectureOrderCommand command);
 
   CreateOrderResult createMentoringOrder(CreateMentoringOrderCommand command);
+
+  CancelOrderResult cancelLectureOrder(CancelLectureOrderCommand command);
+
+  CancelOrderResult cancelMentoringOrder(CancelMentoringOrderCommand command);
 }

--- a/src/main/java/com/goggles/orderservice/application/service/impl/OrderCommandServiceImpl.java
+++ b/src/main/java/com/goggles/orderservice/application/service/impl/OrderCommandServiceImpl.java
@@ -28,6 +28,7 @@ import com.goggles.orderservice.domain.model.OrderItemType;
 import com.goggles.orderservice.domain.model.OrderPrice;
 import com.goggles.orderservice.domain.model.Orderer;
 import com.goggles.orderservice.domain.repository.OrderRepository;
+import com.goggles.orderservice.domain.util.OrderNameBuilder;
 import jakarta.transaction.Transactional;
 import java.util.List;
 import java.util.UUID;
@@ -64,7 +65,8 @@ public class OrderCommandServiceImpl implements OrderCommandService {
               orderEvents);
 
       order = orderRepository.createOrder(order);
-      return CreateOrderResult.from(order);
+      String orderName = OrderNameBuilder.build(order.getItems());
+      return CreateOrderResult.of(order, orderName);
     } catch (Exception e) {
       log.error(
           "[강의 생성 실패] userId: {}, lectureIds: {}, cause: {}",
@@ -74,7 +76,8 @@ public class OrderCommandServiceImpl implements OrderCommandService {
           e);
       compensateLectureReservation(
           productInfo.stream().map(ProductReserveInfo::enrollmentId).toList(),
-          userInfo.userId(), command.userRole());
+          userInfo.userId(),
+          command.userRole());
       throw e;
     }
   }
@@ -192,8 +195,7 @@ public class OrderCommandServiceImpl implements OrderCommandService {
     }
   }
 
-  private void compensateMentoringReservation(
-      UUID enrollmentId, UUID userId, UserRole userRole) {
+  private void compensateMentoringReservation(UUID enrollmentId, UUID userId, UserRole userRole) {
     try {
       mentoringProvider.rollbackMentoringBooking(
           new RollbackMentoringBookingData(

--- a/src/main/java/com/goggles/orderservice/application/service/impl/OrderCommandServiceImpl.java
+++ b/src/main/java/com/goggles/orderservice/application/service/impl/OrderCommandServiceImpl.java
@@ -1,6 +1,8 @@
 package com.goggles.orderservice.application.service.impl;
 
 import com.goggles.orderservice.application.common.UserRole;
+import com.goggles.orderservice.application.dto.command.CancelLectureOrderCommand;
+import com.goggles.orderservice.application.dto.command.CancelMentoringOrderCommand;
 import com.goggles.orderservice.application.dto.command.CreateLectureOrderCommand;
 import com.goggles.orderservice.application.dto.command.CreateMentoringOrderCommand;
 import com.goggles.orderservice.application.dto.external.CancelLectureEnrollmentData;
@@ -8,13 +10,17 @@ import com.goggles.orderservice.application.dto.external.CancelMentoringBookingD
 import com.goggles.orderservice.application.dto.external.LectureProductReserveData;
 import com.goggles.orderservice.application.dto.external.MentoringProductReserveData;
 import com.goggles.orderservice.application.dto.external.ProductReserveInfo;
+import com.goggles.orderservice.application.dto.external.RollbackLectureEnrollmentData;
+import com.goggles.orderservice.application.dto.external.RollbackMentoringBookingData;
 import com.goggles.orderservice.application.dto.external.UserInfo;
+import com.goggles.orderservice.application.dto.result.CancelOrderResult;
 import com.goggles.orderservice.application.dto.result.CreateOrderResult;
 import com.goggles.orderservice.application.port.out.LectureProvider;
 import com.goggles.orderservice.application.port.out.MentoringProvider;
 import com.goggles.orderservice.application.port.out.UserReader;
 import com.goggles.orderservice.application.service.OrderCommandService;
 import com.goggles.orderservice.domain.event.OrderEvents;
+import com.goggles.orderservice.domain.exception.NotFoundOrderException;
 import com.goggles.orderservice.domain.model.CancelReason;
 import com.goggles.orderservice.domain.model.Order;
 import com.goggles.orderservice.domain.model.OrderItemSpec;
@@ -37,6 +43,7 @@ public class OrderCommandServiceImpl implements OrderCommandService {
   private final MentoringProvider mentoringProvider;
   private final UserReader userReader;
   private final OrderRepository orderRepository;
+
   private final OrderEvents orderEvents;
 
   @Override
@@ -65,7 +72,9 @@ public class OrderCommandServiceImpl implements OrderCommandService {
           productInfo.stream().map(ProductReserveInfo::productId).toList(),
           e.getMessage(),
           e);
-      compensateLectureReservation(productInfo, userInfo.userId(), command.userRole());
+      compensateLectureReservation(
+          productInfo.stream().map(ProductReserveInfo::enrollmentId).toList(),
+          userInfo.userId(), command.userRole());
       throw e;
     }
   }
@@ -95,7 +104,49 @@ public class OrderCommandServiceImpl implements OrderCommandService {
           productInfo.enrollmentId(),
           e.getMessage(),
           e);
-      compensateMentoringReservation(productInfo, userInfo.userId(), command.userRole());
+      compensateMentoringReservation(
+          productInfo.enrollmentId(), userInfo.userId(), command.userRole());
+      throw e;
+    }
+  }
+
+  @Override
+  @Transactional
+  public CancelOrderResult cancelLectureOrder(CancelLectureOrderCommand command) {
+    UserInfo userInfo = getUserInfo(command.userId());
+    Order order = getOrderByIdAndUserId(command.orderId(), command.userId());
+
+    try {
+      lectureProvider.cancelLectureEnrollment(CancelLectureEnrollmentData.from(command));
+      order.cancel(CancelReason.from(command.cancelReason()), command.cancelDescription());
+      return CancelOrderResult.from(order);
+    } catch (Exception e) {
+      log.error(
+          "[강의 주문 취소 실패] userId: {}, enrollmentIds: {}, cause: {}",
+          userInfo.userId(),
+          command.enrollmentIds().stream().toList(),
+          e.getMessage(),
+          e);
+      throw e;
+    }
+  }
+
+  @Override
+  public CancelOrderResult cancelMentoringOrder(CancelMentoringOrderCommand command) {
+    UserInfo userInfo = getUserInfo(command.userId());
+    Order order = getOrderByIdAndUserId(command.orderId(), command.userId());
+
+    try {
+      mentoringProvider.cancelMentoringBooking(CancelMentoringBookingData.from(command));
+      order.cancel(CancelReason.from(command.cancelReason()), command.cancelDescription());
+      return CancelOrderResult.from(order);
+    } catch (Exception e) {
+      log.error(
+          "[멘토링 주문 취소 실패] userId: {}, mentoringId: {}, cause: {}",
+          userInfo.userId(),
+          command.enrollmentId(),
+          e.getMessage(),
+          e);
       throw e;
     }
   }
@@ -123,13 +174,18 @@ public class OrderCommandServiceImpl implements OrderCommandService {
     return productInfo.stream().map(product -> product.toOrderItemSpec(type)).toList();
   }
 
+  private Order getOrderByIdAndUserId(UUID orderId, UUID userId) {
+    return orderRepository
+        .getOrderByIdAndUserId(orderId, userId)
+        .orElseThrow(NotFoundOrderException::new);
+  }
+
   private void compensateLectureReservation(
-      List<ProductReserveInfo> productInfo, UUID userId, UserRole userRole) {
-    List<UUID> enrollmentIds = productInfo.stream().map(ProductReserveInfo::enrollmentId).toList();
+      List<UUID> enrollmentIds, UUID userId, UserRole userRole) {
     try {
-      lectureProvider.cancelLectureEnrollment(
-          CancelLectureEnrollmentData.of(
-              userId, userRole, enrollmentIds, CancelReason.SYSTEM_ERROR));
+      lectureProvider.rollbackLectureEnrollment(
+          new RollbackLectureEnrollmentData(
+              userId, userRole, enrollmentIds, CancelReason.SYSTEM_ERROR.name()));
     } catch (Exception e) {
       log.error("강의 예약 보상 트랜잭션 실패. enrollmentIds: {}", enrollmentIds);
       // todo: DLQ 적용
@@ -137,13 +193,13 @@ public class OrderCommandServiceImpl implements OrderCommandService {
   }
 
   private void compensateMentoringReservation(
-      ProductReserveInfo productInfo, UUID userId, UserRole userRole) {
+      UUID enrollmentId, UUID userId, UserRole userRole) {
     try {
-      mentoringProvider.cancelMentoringBooking(
-          CancelMentoringBookingData.of(
-              userId, userRole, productInfo.enrollmentId(), CancelReason.SYSTEM_ERROR));
+      mentoringProvider.rollbackMentoringBooking(
+          new RollbackMentoringBookingData(
+              userId, userRole, enrollmentId, CancelReason.SYSTEM_ERROR.name()));
     } catch (Exception e) {
-      log.error("멘토링 예약 보상 트랜잭션 실패. enrollmentId: {}", productInfo.enrollmentId());
+      log.error("멘토링 예약 보상 트랜잭션 실패. enrollmentId: {}", enrollmentId);
       // todo: DLQ 적용
     }
   }

--- a/src/main/java/com/goggles/orderservice/application/service/impl/OrderCommandServiceImpl.java
+++ b/src/main/java/com/goggles/orderservice/application/service/impl/OrderCommandServiceImpl.java
@@ -120,8 +120,8 @@ public class OrderCommandServiceImpl implements OrderCommandService {
     Order order = getOrderByIdAndUserId(command.orderId(), command.userId());
 
     try {
-      lectureProvider.cancelLectureEnrollment(CancelLectureEnrollmentData.from(command));
       order.cancel(CancelReason.from(command.cancelReason()), command.cancelDescription());
+      lectureProvider.cancelLectureEnrollment(CancelLectureEnrollmentData.from(command));
       return CancelOrderResult.from(order);
     } catch (Exception e) {
       log.error(
@@ -135,13 +135,14 @@ public class OrderCommandServiceImpl implements OrderCommandService {
   }
 
   @Override
+  @Transactional
   public CancelOrderResult cancelMentoringOrder(CancelMentoringOrderCommand command) {
     UserInfo userInfo = getUserInfo(command.userId());
     Order order = getOrderByIdAndUserId(command.orderId(), command.userId());
 
     try {
-      mentoringProvider.cancelMentoringBooking(CancelMentoringBookingData.from(command));
       order.cancel(CancelReason.from(command.cancelReason()), command.cancelDescription());
+      mentoringProvider.cancelMentoringBooking(CancelMentoringBookingData.from(command));
       return CancelOrderResult.from(order);
     } catch (Exception e) {
       log.error(

--- a/src/main/java/com/goggles/orderservice/domain/event/OrderPaymentPendingEvent.java
+++ b/src/main/java/com/goggles/orderservice/domain/event/OrderPaymentPendingEvent.java
@@ -1,6 +1,7 @@
 package com.goggles.orderservice.domain.event;
 
 import com.goggles.orderservice.domain.model.Order;
+import com.goggles.orderservice.domain.util.OrderNameBuilder;
 import java.util.UUID;
 
 public record OrderPaymentPendingEvent(
@@ -11,22 +12,12 @@ public record OrderPaymentPendingEvent(
     String customerEmail,
     String orderName) {
   public static OrderPaymentPendingEvent from(Order order) {
-    String buildOrderName;
-    if (order.getItems().size() > 1) {
-      buildOrderName =
-          order.getItems().getFirst().getProduct().getProductName()
-              + "외 "
-              + (order.getItems().size() - 1)
-              + "건";
-    } else {
-      buildOrderName = order.getItems().getFirst().getProduct().getProductName();
-    }
     return new OrderPaymentPendingEvent(
         order.getId(),
         order.getPrice().getFinalPrice(),
         order.getOrderer().getStudentId(),
         order.getOrderer().getStudentName(),
         order.getOrderer().getStudentEmail(),
-        buildOrderName);
+        OrderNameBuilder.build(order.getItems()));
   }
 }

--- a/src/main/java/com/goggles/orderservice/domain/util/OrderNameBuilder.java
+++ b/src/main/java/com/goggles/orderservice/domain/util/OrderNameBuilder.java
@@ -1,0 +1,23 @@
+package com.goggles.orderservice.domain.util;
+
+import com.goggles.orderservice.domain.model.OrderItem;
+import java.util.List;
+
+public class OrderNameBuilder {
+
+  private OrderNameBuilder() {}
+
+  public static String build(List<OrderItem> items) {
+    if (items == null || items.isEmpty()) {
+      throw new IllegalArgumentException("주문 아이템이 비어있습니다.");
+    }
+
+    String firstName = items.getFirst().getProduct().getProductName();
+
+    if (items.size() == 1) {
+      return firstName;
+    }
+
+    return firstName + " 외 " + (items.size() - 1) + "건";
+  }
+}

--- a/src/main/java/com/goggles/orderservice/infrastructure/client/LectureClient.java
+++ b/src/main/java/com/goggles/orderservice/infrastructure/client/LectureClient.java
@@ -4,6 +4,7 @@ import com.goggles.common.response.ApiResponse;
 import com.goggles.orderservice.infrastructure.client.dto.CancelLectureEnrollmentRequest;
 import com.goggles.orderservice.infrastructure.client.dto.ReserveLectureRequest;
 import com.goggles.orderservice.infrastructure.client.dto.ReserveProductResponse;
+import com.goggles.orderservice.infrastructure.client.dto.RollbackLectureEnrollmentRequest;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.cloud.openfeign.FeignClient;
@@ -18,6 +19,12 @@ public interface LectureClient {
       @RequestHeader("X-User-Id") UUID userId,
       @RequestHeader("X-User-Role") String userRole,
       @RequestBody ReserveLectureRequest request);
+
+  @PostMapping("/internal/v1/lectures-enrollment/rollback")
+  void rollbackLecturesEnrollment(
+      @RequestHeader("X-User-Id") UUID userId,
+      @RequestHeader("X-User-Role") String userRole,
+      @RequestBody RollbackLectureEnrollmentRequest request);
 
   @PostMapping("/internal/v1/lectures-enrollment/cancellation")
   void cancelLecturesEnrollment(

--- a/src/main/java/com/goggles/orderservice/infrastructure/client/LectureClient.java
+++ b/src/main/java/com/goggles/orderservice/infrastructure/client/LectureClient.java
@@ -27,7 +27,7 @@ public interface LectureClient {
       @RequestBody RollbackLectureEnrollmentRequest request);
 
   @PostMapping("/internal/v1/lectures-enrollment/cancellation")
-  void cancelLecturesEnrollment(
+  void cancelLectureEnrollment(
       @RequestHeader("X-User-Id") UUID userId,
       @RequestHeader("X-User-Role") String userRole,
       @RequestBody CancelLectureEnrollmentRequest request);

--- a/src/main/java/com/goggles/orderservice/infrastructure/client/LectureClient.java
+++ b/src/main/java/com/goggles/orderservice/infrastructure/client/LectureClient.java
@@ -21,7 +21,7 @@ public interface LectureClient {
       @RequestBody ReserveLectureRequest request);
 
   @PostMapping("/internal/v1/lectures-enrollment/rollback")
-  void rollbackLecturesEnrollment(
+  void rollbackLectureEnrollment(
       @RequestHeader("X-User-Id") UUID userId,
       @RequestHeader("X-User-Role") String userRole,
       @RequestBody RollbackLectureEnrollmentRequest request);

--- a/src/main/java/com/goggles/orderservice/infrastructure/client/LectureClientAdapter.java
+++ b/src/main/java/com/goggles/orderservice/infrastructure/client/LectureClientAdapter.java
@@ -39,7 +39,11 @@ public class LectureClientAdapter implements LectureProvider {
 
   private List<ProductReserveInfo> reserveEnrollmentFallback(
       LectureProductReserveData data, Throwable t) {
-    log.warn("lecture-service reserve fallback. type: {}, cause: {}", t.getClass().getName(), t.getMessage(), t);
+    log.warn(
+        "lecture-service reserve fallback. type: {}, cause: {}",
+        t.getClass().getName(),
+        t.getMessage(),
+        t);
 
     if (t instanceof CallNotPermittedException) {
       throw new ExternalServiceException("현재 서비스가 일시적으로 불안정합니다. 잠시 후 다시 시도해주세요.");
@@ -51,7 +55,9 @@ public class LectureClientAdapter implements LectureProvider {
   }
 
   @Override
-  @CircuitBreaker(name = "lecture-service-cancel", fallbackMethod = "cancelLectureEnrollmentFallback")
+  @CircuitBreaker(
+      name = "lecture-service-cancel",
+      fallbackMethod = "cancelLectureEnrollmentFallback")
   @Retry(name = "lecture-service-cancel")
   public void cancelLectureEnrollment(CancelLectureEnrollmentData data) {
     lectureClient.cancelLectureEnrollment(
@@ -74,7 +80,8 @@ public class LectureClientAdapter implements LectureProvider {
 
   @Override
   @CircuitBreaker(
-      name = "lecture-service-rollback", fallbackMethod = "rollbackLectureEnrollmentFallback")
+      name = "lecture-service-rollback",
+      fallbackMethod = "rollbackLectureEnrollmentFallback")
   @Retry(name = "lecture-service-rollback")
   public void rollbackLectureEnrollment(RollbackLectureEnrollmentData data) {
     lectureClient.rollbackLecturesEnrollment(
@@ -92,5 +99,4 @@ public class LectureClientAdapter implements LectureProvider {
 
     throw new ExternalServiceException("강의 등록 취소 처리 중 오류가 발생했습니다.");
   }
-
 }

--- a/src/main/java/com/goggles/orderservice/infrastructure/client/LectureClientAdapter.java
+++ b/src/main/java/com/goggles/orderservice/infrastructure/client/LectureClientAdapter.java
@@ -39,9 +39,7 @@ public class LectureClientAdapter implements LectureProvider {
 
   private List<ProductReserveInfo> reserveEnrollmentFallback(
       LectureProductReserveData data, Throwable t) {
-    log.warn("lecture-service fallback. cause: {}", t.getMessage());
-    log.warn("lecture-service fallback. exception type: {}", t.getClass().getName());
-    log.warn("lecture-service fallback. stacktrace: ", t);
+    log.warn("lecture-service reserve fallback. type: {}, cause: {}", t.getClass().getName(), t.getMessage(), t);
 
     if (t instanceof CallNotPermittedException) {
       throw new ExternalServiceException("현재 서비스가 일시적으로 불안정합니다. 잠시 후 다시 시도해주세요.");
@@ -53,9 +51,30 @@ public class LectureClientAdapter implements LectureProvider {
   }
 
   @Override
+  @CircuitBreaker(name = "lecture-service-cancel", fallbackMethod = "cancelLectureEnrollmentFallback")
+  @Retry(name = "lecture-service-cancel")
+  public void cancelLectureEnrollment(CancelLectureEnrollmentData data) {
+    lectureClient.cancelLectureEnrollment(
+        data.userId(), data.userRole().name(), CancelLectureEnrollmentRequest.from(data));
+  }
+
+  private void cancelLectureEnrollmentFallback(CancelLectureEnrollmentData data, Throwable t) {
+    log.error(
+        "[강의 주문 취소 최종 실패] userId: {}, enrollmentIds: {}, cause: {}",
+        data.userId(),
+        data.enrollmentIds(),
+        t.getMessage(),
+        t);
+
+    if (t instanceof CallNotPermittedException) {
+      throw new ExternalServiceException("현재 서비스가 일시적으로 불안정합니다. 잠시 후 다시 시도해주세요.");
+    }
+    throw new ExternalServiceException("강의 주문 취소 처리 중 오류가 발생했습니다.");
+  }
+
+  @Override
   @CircuitBreaker(
-      name = "lecture-service-rollback",
-      fallbackMethod = "rollbackLectureEnrollmentFallback")
+      name = "lecture-service-rollback", fallbackMethod = "rollbackLectureEnrollmentFallback")
   @Retry(name = "lecture-service-rollback")
   public void rollbackLectureEnrollment(RollbackLectureEnrollmentData data) {
     lectureClient.rollbackLecturesEnrollment(
@@ -74,27 +93,4 @@ public class LectureClientAdapter implements LectureProvider {
     throw new ExternalServiceException("강의 등록 취소 처리 중 오류가 발생했습니다.");
   }
 
-  @Override
-  @CircuitBreaker(
-      name = "lecture-service-cancel",
-      fallbackMethod = "cancelLectureEnrollmentFallback")
-  @Retry(name = "lecture-service-cancel")
-  public void cancelLectureEnrollment(CancelLectureEnrollmentData data) {
-    lectureClient.cancelLecturesEnrollment(
-        data.userId(), data.userRole().name(), CancelLectureEnrollmentRequest.from(data));
-  }
-
-  private void cancelLectureEnrollmentFallback(CancelLectureEnrollmentData data, Throwable t) {
-    log.error(
-        "[강의 등록 취소 최종 실패] userId: {}, enrollmentIds: {}, cause: {}",
-        data.userId(),
-        data.enrollmentIds(),
-        t.getMessage(),
-        t);
-
-    if (t instanceof CallNotPermittedException) {
-      throw new ExternalServiceException("현재 서비스가 일시적으로 불안정합니다. 잠시 후 다시 시도해주세요.");
-    }
-    throw new ExternalServiceException("강의 등록 취소 처리 중 오류가 발생했습니다.");
-  }
 }

--- a/src/main/java/com/goggles/orderservice/infrastructure/client/LectureClientAdapter.java
+++ b/src/main/java/com/goggles/orderservice/infrastructure/client/LectureClientAdapter.java
@@ -4,10 +4,12 @@ import com.goggles.common.response.ApiResponse;
 import com.goggles.orderservice.application.dto.external.CancelLectureEnrollmentData;
 import com.goggles.orderservice.application.dto.external.LectureProductReserveData;
 import com.goggles.orderservice.application.dto.external.ProductReserveInfo;
+import com.goggles.orderservice.application.dto.external.RollbackLectureEnrollmentData;
 import com.goggles.orderservice.application.port.out.LectureProvider;
 import com.goggles.orderservice.infrastructure.client.dto.CancelLectureEnrollmentRequest;
 import com.goggles.orderservice.infrastructure.client.dto.ReserveLectureRequest;
 import com.goggles.orderservice.infrastructure.client.dto.ReserveProductResponse;
+import com.goggles.orderservice.infrastructure.client.dto.RollbackLectureEnrollmentRequest;
 import com.goggles.orderservice.infrastructure.client.exception.ExternalServiceException;
 import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
 import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
@@ -52,23 +54,47 @@ public class LectureClientAdapter implements LectureProvider {
 
   @Override
   @CircuitBreaker(
+      name = "lecture-service-rollback",
+      fallbackMethod = "rollbackLectureEnrollmentFallback")
+  @Retry(name = "lecture-service-rollback")
+  public void rollbackLectureEnrollment(RollbackLectureEnrollmentData data) {
+    lectureClient.rollbackLecturesEnrollment(
+        data.userId(), data.userRole().name(), RollbackLectureEnrollmentRequest.from(data));
+  }
+
+  private void rollbackLectureEnrollmentFallback(RollbackLectureEnrollmentData data, Throwable t) {
+    log.error(
+        "[강의 등록 취소 보상 트랜잭션 최종 실패] " + "userId: {}, enrollmentId: {}, cancelReason: {}, cause: {}",
+        data.userId(),
+        data.enrollmentIds(),
+        data.cancelReason(),
+        t.getMessage(),
+        t);
+
+    throw new ExternalServiceException("강의 등록 취소 처리 중 오류가 발생했습니다.");
+  }
+
+  @Override
+  @CircuitBreaker(
       name = "lecture-service-cancel",
       fallbackMethod = "cancelLectureEnrollmentFallback")
   @Retry(name = "lecture-service-cancel")
   public void cancelLectureEnrollment(CancelLectureEnrollmentData data) {
     lectureClient.cancelLecturesEnrollment(
-        data.userId(), data.userRole().name(), CancelLectureEnrollmentRequest.of(data));
+        data.userId(), data.userRole().name(), CancelLectureEnrollmentRequest.from(data));
   }
 
   private void cancelLectureEnrollmentFallback(CancelLectureEnrollmentData data, Throwable t) {
     log.error(
-        "[강의 등록 취소 보상 트랜잭션 최종 실패] " + "userId: {}, enrollmentId: {}, cancelReason: {}, cause: {}",
+        "[강의 등록 취소 최종 실패] userId: {}, enrollmentIds: {}, cause: {}",
         data.userId(),
-        data.LectureEnrollmentIds(),
-        data.cancelReason(),
+        data.enrollmentIds(),
         t.getMessage(),
         t);
 
+    if (t instanceof CallNotPermittedException) {
+      throw new ExternalServiceException("현재 서비스가 일시적으로 불안정합니다. 잠시 후 다시 시도해주세요.");
+    }
     throw new ExternalServiceException("강의 등록 취소 처리 중 오류가 발생했습니다.");
   }
 }

--- a/src/main/java/com/goggles/orderservice/infrastructure/client/LectureClientAdapter.java
+++ b/src/main/java/com/goggles/orderservice/infrastructure/client/LectureClientAdapter.java
@@ -84,7 +84,7 @@ public class LectureClientAdapter implements LectureProvider {
       fallbackMethod = "rollbackLectureEnrollmentFallback")
   @Retry(name = "lecture-service-rollback")
   public void rollbackLectureEnrollment(RollbackLectureEnrollmentData data) {
-    lectureClient.rollbackLecturesEnrollment(
+    lectureClient.rollbackLectureEnrollment(
         data.userId(), data.userRole().name(), RollbackLectureEnrollmentRequest.from(data));
   }
 

--- a/src/main/java/com/goggles/orderservice/infrastructure/client/MentoringClient.java
+++ b/src/main/java/com/goggles/orderservice/infrastructure/client/MentoringClient.java
@@ -4,6 +4,7 @@ import com.goggles.common.response.ApiResponse;
 import com.goggles.orderservice.infrastructure.client.dto.CancelMentoringBookingRequest;
 import com.goggles.orderservice.infrastructure.client.dto.ReserveMentoringRequest;
 import com.goggles.orderservice.infrastructure.client.dto.ReserveProductResponse;
+import com.goggles.orderservice.infrastructure.client.dto.RollbackMentoringBookingRequest;
 import java.util.UUID;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -20,6 +21,13 @@ public interface MentoringClient {
       @RequestHeader("X-User-Role") String userRole,
       @RequestHeader("X-User-Name") String userName,
       @RequestBody ReserveMentoringRequest request);
+
+  @PatchMapping("/internal/v1/mentoring-booking/{bookingId}/rollback")
+  void rollbackMentoringBooking(
+      @RequestHeader("X-User-Id") UUID userId,
+      @RequestHeader("X-User-Role") String userRole,
+      @PathVariable("bookingId") UUID bookingId,
+      @RequestBody RollbackMentoringBookingRequest request);
 
   @PatchMapping("/internal/v1/mentoring-booking/{bookingId}/cancellation")
   void cancelMentoringBooking(

--- a/src/main/java/com/goggles/orderservice/infrastructure/client/MentoringClientAdapter.java
+++ b/src/main/java/com/goggles/orderservice/infrastructure/client/MentoringClientAdapter.java
@@ -4,10 +4,12 @@ import com.goggles.common.response.ApiResponse;
 import com.goggles.orderservice.application.dto.external.CancelMentoringBookingData;
 import com.goggles.orderservice.application.dto.external.MentoringProductReserveData;
 import com.goggles.orderservice.application.dto.external.ProductReserveInfo;
+import com.goggles.orderservice.application.dto.external.RollbackMentoringBookingData;
 import com.goggles.orderservice.application.port.out.MentoringProvider;
 import com.goggles.orderservice.infrastructure.client.dto.CancelMentoringBookingRequest;
 import com.goggles.orderservice.infrastructure.client.dto.ReserveMentoringRequest;
 import com.goggles.orderservice.infrastructure.client.dto.ReserveProductResponse;
+import com.goggles.orderservice.infrastructure.client.dto.RollbackMentoringBookingRequest;
 import com.goggles.orderservice.infrastructure.client.exception.ExternalServiceException;
 import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
 import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
@@ -39,9 +41,7 @@ public class MentoringClientAdapter implements MentoringProvider {
 
   private ProductReserveInfo reserveEnrollmentFallback(
       MentoringProductReserveData data, Throwable t) {
-    log.warn("mentoring-service fallback. cause: {}", t.getMessage());
-    log.warn("mentoring-service fallback. exception type: {}", t.getClass().getName());
-    log.warn("mentoring-service fallback. stacktrace: ", t);
+    log.warn("mentoring-service reserve fallback. type: {}, cause: {}", t.getClass().getName(), t.getMessage(), t);
 
     if (t instanceof CallNotPermittedException) {
       throw new ExternalServiceException("현재 서비스가 일시적으로 불안정합니다. 잠시 후 다시 시도해주세요.");
@@ -53,27 +53,50 @@ public class MentoringClientAdapter implements MentoringProvider {
   }
 
   @Override
-  @CircuitBreaker(
-      name = "mentoring-service-cancel",
-      fallbackMethod = "cancelMentoringBookingFallback")
+  @CircuitBreaker(name = "mentoring-service-cancel", fallbackMethod = "cancelMentoringBookingFallback")
   @Retry(name = "mentoring-service-cancel")
   public void cancelMentoringBooking(CancelMentoringBookingData data) {
     mentoringClient.cancelMentoringBooking(
-        data.userId(),
-        data.userRole().name(),
-        data.mentoringBookingId(),
-        CancelMentoringBookingRequest.of(data));
+        data.userId(), data.userRole().name(), data.bookingId(), CancelMentoringBookingRequest.from(data));
   }
 
   private void cancelMentoringBookingFallback(CancelMentoringBookingData data, Throwable t) {
     log.error(
-        "[멘토링 취소 보상 트랜잭션 최종 실패] " + "userId: {}, enrollmentId: {}, cancelReason: {}, cause: {}",
+        "[멘토링 주문 취소 최종 실패] " + "userId: {}, bookingId: {}, cause: {}",
         data.userId(),
-        data.mentoringBookingId(),
+        data.bookingId(),
+        t.getMessage(),
+        t);
+
+    if (t instanceof CallNotPermittedException) {
+      throw new ExternalServiceException("현재 서비스가 일시적으로 불안정합니다. 잠시 후 다시 시도해주세요.");
+    }
+    throw new ExternalServiceException("멘토링 주문 취소 처리 중 오류가 발생했습니다.");
+  }
+
+  @Override
+  @CircuitBreaker(
+      name = "mentoring-service-rollback",
+      fallbackMethod = "rollbackMentoringBookingFallback")
+  @Retry(name = "mentoring-service-rollback")
+  public void rollbackMentoringBooking(RollbackMentoringBookingData data) {
+    mentoringClient.rollbackMentoringBooking(
+        data.userId(),
+        data.userRole().name(),
+        data.bookingId(),
+        new RollbackMentoringBookingRequest(data.cancelReason()));
+  }
+
+  private void rollbackMentoringBookingFallback(RollbackMentoringBookingData data, Throwable t) {
+    log.error(
+        "[멘토링 등록 취소 보상 트랜잭션 최종 실패] " + "userId: {}, bookingId: {}, cancelReason: {}, cause: {}",
+        data.userId(),
+        data.bookingId(),
         data.cancelReason(),
         t.getMessage(),
         t);
 
-    throw new ExternalServiceException("멘토링 취소 처리 중 오류가 발생했습니다.");
+    throw new ExternalServiceException("멘토링 등록 취소 처리 중 오류가 발생했습니다.");
   }
+
 }

--- a/src/main/java/com/goggles/orderservice/infrastructure/client/MentoringClientAdapter.java
+++ b/src/main/java/com/goggles/orderservice/infrastructure/client/MentoringClientAdapter.java
@@ -41,7 +41,11 @@ public class MentoringClientAdapter implements MentoringProvider {
 
   private ProductReserveInfo reserveEnrollmentFallback(
       MentoringProductReserveData data, Throwable t) {
-    log.warn("mentoring-service reserve fallback. type: {}, cause: {}", t.getClass().getName(), t.getMessage(), t);
+    log.warn(
+        "mentoring-service reserve fallback. type: {}, cause: {}",
+        t.getClass().getName(),
+        t.getMessage(),
+        t);
 
     if (t instanceof CallNotPermittedException) {
       throw new ExternalServiceException("현재 서비스가 일시적으로 불안정합니다. 잠시 후 다시 시도해주세요.");
@@ -53,11 +57,16 @@ public class MentoringClientAdapter implements MentoringProvider {
   }
 
   @Override
-  @CircuitBreaker(name = "mentoring-service-cancel", fallbackMethod = "cancelMentoringBookingFallback")
+  @CircuitBreaker(
+      name = "mentoring-service-cancel",
+      fallbackMethod = "cancelMentoringBookingFallback")
   @Retry(name = "mentoring-service-cancel")
   public void cancelMentoringBooking(CancelMentoringBookingData data) {
     mentoringClient.cancelMentoringBooking(
-        data.userId(), data.userRole().name(), data.bookingId(), CancelMentoringBookingRequest.from(data));
+        data.userId(),
+        data.userRole().name(),
+        data.bookingId(),
+        CancelMentoringBookingRequest.from(data));
   }
 
   private void cancelMentoringBookingFallback(CancelMentoringBookingData data, Throwable t) {
@@ -98,5 +107,4 @@ public class MentoringClientAdapter implements MentoringProvider {
 
     throw new ExternalServiceException("멘토링 등록 취소 처리 중 오류가 발생했습니다.");
   }
-
 }

--- a/src/main/java/com/goggles/orderservice/infrastructure/client/dto/CancelLectureEnrollmentRequest.java
+++ b/src/main/java/com/goggles/orderservice/infrastructure/client/dto/CancelLectureEnrollmentRequest.java
@@ -3,19 +3,11 @@ package com.goggles.orderservice.infrastructure.client.dto;
 import com.goggles.orderservice.application.dto.external.CancelLectureEnrollmentData;
 import java.util.List;
 import java.util.UUID;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
-@Getter
-@NoArgsConstructor
-@AllArgsConstructor
-public class CancelLectureEnrollmentRequest {
-  private List<UUID> mentoringBookingIds;
-  private String cancelReason;
-
-  public static CancelLectureEnrollmentRequest of(CancelLectureEnrollmentData data) {
+public record CancelLectureEnrollmentRequest(
+    UUID orderId, List<UUID> enrollmentIds, String cancelReason, String cancelDescription) {
+  public static CancelLectureEnrollmentRequest from(CancelLectureEnrollmentData data) {
     return new CancelLectureEnrollmentRequest(
-        data.LectureEnrollmentIds(), data.cancelReason().name());
+        data.orderId(), data.enrollmentIds(), data.cancelReason(), data.cancelDescription());
   }
 }

--- a/src/main/java/com/goggles/orderservice/infrastructure/client/dto/CancelMentoringBookingRequest.java
+++ b/src/main/java/com/goggles/orderservice/infrastructure/client/dto/CancelMentoringBookingRequest.java
@@ -4,10 +4,7 @@ import com.goggles.orderservice.application.dto.external.CancelMentoringBookingD
 import java.util.UUID;
 
 public record CancelMentoringBookingRequest(
-    UUID orderId,
-    String cancelReason,
-    String cancelDescription
-){
+    UUID orderId, String cancelReason, String cancelDescription) {
   public static CancelMentoringBookingRequest from(CancelMentoringBookingData data) {
     return new CancelMentoringBookingRequest(
         data.orderId(), data.cancelReason(), data.cancelDescription());

--- a/src/main/java/com/goggles/orderservice/infrastructure/client/dto/CancelMentoringBookingRequest.java
+++ b/src/main/java/com/goggles/orderservice/infrastructure/client/dto/CancelMentoringBookingRequest.java
@@ -1,17 +1,15 @@
 package com.goggles.orderservice.infrastructure.client.dto;
 
 import com.goggles.orderservice.application.dto.external.CancelMentoringBookingData;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import java.util.UUID;
 
-@Getter
-@NoArgsConstructor
-@AllArgsConstructor
-public class CancelMentoringBookingRequest {
-  private String cancelReason;
-
-  public static CancelMentoringBookingRequest of(CancelMentoringBookingData data) {
-    return new CancelMentoringBookingRequest(data.cancelReason().name());
+public record CancelMentoringBookingRequest(
+    UUID orderId,
+    String cancelReason,
+    String cancelDescription
+){
+  public static CancelMentoringBookingRequest from(CancelMentoringBookingData data) {
+    return new CancelMentoringBookingRequest(
+        data.orderId(), data.cancelReason(), data.cancelDescription());
   }
 }

--- a/src/main/java/com/goggles/orderservice/infrastructure/client/dto/RollbackLectureEnrollmentRequest.java
+++ b/src/main/java/com/goggles/orderservice/infrastructure/client/dto/RollbackLectureEnrollmentRequest.java
@@ -1,0 +1,11 @@
+package com.goggles.orderservice.infrastructure.client.dto;
+
+import com.goggles.orderservice.application.dto.external.RollbackLectureEnrollmentData;
+import java.util.List;
+import java.util.UUID;
+
+public record RollbackLectureEnrollmentRequest(List<UUID> enrollmentIds, String cancelReason) {
+  public static RollbackLectureEnrollmentRequest from(RollbackLectureEnrollmentData data) {
+    return new RollbackLectureEnrollmentRequest(data.enrollmentIds(), data.cancelReason());
+  }
+}

--- a/src/main/java/com/goggles/orderservice/infrastructure/client/dto/RollbackMentoringBookingRequest.java
+++ b/src/main/java/com/goggles/orderservice/infrastructure/client/dto/RollbackMentoringBookingRequest.java
@@ -1,0 +1,3 @@
+package com.goggles.orderservice.infrastructure.client.dto;
+
+public record RollbackMentoringBookingRequest(String cancelReason) {}

--- a/src/main/java/com/goggles/orderservice/infrastructure/config/Resilience4JConfig.java
+++ b/src/main/java/com/goggles/orderservice/infrastructure/config/Resilience4JConfig.java
@@ -18,53 +18,73 @@ public class Resilience4JConfig {
 
   @Bean
   public Customizer<Resilience4JCircuitBreakerFactory> circuitBreakerFactoryCustomizer(
-      CircuitBreakerRegistry circuitBreakerRegistry,
-      TimeLimiterRegistry timeLimiterRegistry) {
+      CircuitBreakerRegistry circuitBreakerRegistry, TimeLimiterRegistry timeLimiterRegistry) {
 
     return factory -> {
       factory.configure(
-          builder -> builder
-              .timeLimiterConfig(timeLimiterRegistry.getConfiguration("default-write")
-                  .orElse(timeLimiterRegistry.getDefaultConfig()))
-              .circuitBreakerConfig(circuitBreakerRegistry.getConfiguration("default-write")
-                  .orElse(circuitBreakerRegistry.getDefaultConfig()))
-              .build(),
+          builder ->
+              builder
+                  .timeLimiterConfig(
+                      timeLimiterRegistry
+                          .getConfiguration("default-write")
+                          .orElse(timeLimiterRegistry.getDefaultConfig()))
+                  .circuitBreakerConfig(
+                      circuitBreakerRegistry
+                          .getConfiguration("default-write")
+                          .orElse(circuitBreakerRegistry.getDefaultConfig()))
+                  .build(),
           "lecture-service-write",
           "mentoring-service-write",
           "lecture-service-cancel",
           "mentoring-service-cancel");
 
       factory.configure(
-          builder -> builder
-              .timeLimiterConfig(timeLimiterRegistry.getConfiguration("default-rollback")
-                  .orElse(timeLimiterRegistry.getDefaultConfig()))
-              .circuitBreakerConfig(circuitBreakerRegistry.getConfiguration("default-rollback")
-                  .orElse(circuitBreakerRegistry.getDefaultConfig()))
-              .build(),
+          builder ->
+              builder
+                  .timeLimiterConfig(
+                      timeLimiterRegistry
+                          .getConfiguration("default-rollback")
+                          .orElse(timeLimiterRegistry.getDefaultConfig()))
+                  .circuitBreakerConfig(
+                      circuitBreakerRegistry
+                          .getConfiguration("default-rollback")
+                          .orElse(circuitBreakerRegistry.getDefaultConfig()))
+                  .build(),
           "lecture-service-rollback",
           "mentoring-service-rollback");
 
       factory.configure(
-          builder -> builder
-              .timeLimiterConfig(timeLimiterRegistry.getConfiguration("default-read")
-                  .orElse(timeLimiterRegistry.getDefaultConfig()))
-              .circuitBreakerConfig(circuitBreakerRegistry.getConfiguration("default-read")
-                  .orElse(circuitBreakerRegistry.getDefaultConfig()))
-              .build(),
+          builder ->
+              builder
+                  .timeLimiterConfig(
+                      timeLimiterRegistry
+                          .getConfiguration("default-read")
+                          .orElse(timeLimiterRegistry.getDefaultConfig()))
+                  .circuitBreakerConfig(
+                      circuitBreakerRegistry
+                          .getConfiguration("default-read")
+                          .orElse(circuitBreakerRegistry.getDefaultConfig()))
+                  .build(),
           "user-service-read");
 
-      factory.configureDefault(id -> {
-        String configName = id.contains("write") || id.contains("cancel")
-            ? "default-write"
-            : id.contains("rollback") ? "default-rollback" : "default-read";
+      factory.configureDefault(
+          id -> {
+            String configName =
+                id.contains("write") || id.contains("cancel")
+                    ? "default-write"
+                    : id.contains("rollback") ? "default-rollback" : "default-read";
 
-        return new Resilience4JConfigBuilder(id)
-            .timeLimiterConfig(timeLimiterRegistry.getConfiguration(configName)
-                .orElse(timeLimiterRegistry.getDefaultConfig()))
-            .circuitBreakerConfig(circuitBreakerRegistry.getConfiguration(configName)
-                .orElse(circuitBreakerRegistry.getDefaultConfig()))
-            .build();
-      });
+            return new Resilience4JConfigBuilder(id)
+                .timeLimiterConfig(
+                    timeLimiterRegistry
+                        .getConfiguration(configName)
+                        .orElse(timeLimiterRegistry.getDefaultConfig()))
+                .circuitBreakerConfig(
+                    circuitBreakerRegistry
+                        .getConfiguration(configName)
+                        .orElse(circuitBreakerRegistry.getDefaultConfig()))
+                .build();
+          });
     };
   }
 }

--- a/src/main/java/com/goggles/orderservice/infrastructure/config/Resilience4JConfig.java
+++ b/src/main/java/com/goggles/orderservice/infrastructure/config/Resilience4JConfig.java
@@ -17,69 +17,54 @@ public class Resilience4JConfig {
   private final CircuitBreakerRegistry circuitBreakerRegistry;
 
   @Bean
-  public Customizer<Resilience4JCircuitBreakerFactory> circuitBreakerFactoryCustomizer() {
+  public Customizer<Resilience4JCircuitBreakerFactory> circuitBreakerFactoryCustomizer(
+      CircuitBreakerRegistry circuitBreakerRegistry,
+      TimeLimiterRegistry timeLimiterRegistry) {
+
     return factory -> {
       factory.configure(
-          builder ->
-              builder
-                  .timeLimiterConfig(
-                      timeLimiterRegistry
-                          .getConfiguration("default-write")
-                          .orElse(timeLimiterRegistry.getDefaultConfig()))
-                  .circuitBreakerConfig(
-                      circuitBreakerRegistry
-                          .getConfiguration("default-write")
-                          .orElse(circuitBreakerRegistry.getDefaultConfig()))
-                  .build(),
+          builder -> builder
+              .timeLimiterConfig(timeLimiterRegistry.getConfiguration("default-write")
+                  .orElse(timeLimiterRegistry.getDefaultConfig()))
+              .circuitBreakerConfig(circuitBreakerRegistry.getConfiguration("default-write")
+                  .orElse(circuitBreakerRegistry.getDefaultConfig()))
+              .build(),
           "lecture-service-write",
-          "mentoring-service-write");
-
-      factory.configure(
-          builder ->
-              builder
-                  .timeLimiterConfig(
-                      timeLimiterRegistry
-                          .getConfiguration("default-cancel")
-                          .orElse(timeLimiterRegistry.getDefaultConfig()))
-                  .circuitBreakerConfig(
-                      circuitBreakerRegistry
-                          .getConfiguration("default-cancel")
-                          .orElse(circuitBreakerRegistry.getDefaultConfig()))
-                  .build(),
+          "mentoring-service-write",
           "lecture-service-cancel",
           "mentoring-service-cancel");
 
       factory.configure(
-          builder ->
-              builder
-                  .timeLimiterConfig(
-                      timeLimiterRegistry
-                          .getConfiguration("default-read")
-                          .orElse(timeLimiterRegistry.getDefaultConfig()))
-                  .circuitBreakerConfig(
-                      circuitBreakerRegistry
-                          .getConfiguration("default-read")
-                          .orElse(circuitBreakerRegistry.getDefaultConfig()))
-                  .build(),
+          builder -> builder
+              .timeLimiterConfig(timeLimiterRegistry.getConfiguration("default-rollback")
+                  .orElse(timeLimiterRegistry.getDefaultConfig()))
+              .circuitBreakerConfig(circuitBreakerRegistry.getConfiguration("default-rollback")
+                  .orElse(circuitBreakerRegistry.getDefaultConfig()))
+              .build(),
+          "lecture-service-rollback",
+          "mentoring-service-rollback");
+
+      factory.configure(
+          builder -> builder
+              .timeLimiterConfig(timeLimiterRegistry.getConfiguration("default-read")
+                  .orElse(timeLimiterRegistry.getDefaultConfig()))
+              .circuitBreakerConfig(circuitBreakerRegistry.getConfiguration("default-read")
+                  .orElse(circuitBreakerRegistry.getDefaultConfig()))
+              .build(),
           "user-service-read");
 
-      factory.configureDefault(
-          id -> {
-            String configName =
-                id.contains("write")
-                    ? "default-write"
-                    : id.contains("cancel") ? "default-cancel" : "default-read";
-            return new Resilience4JConfigBuilder(id)
-                .timeLimiterConfig(
-                    timeLimiterRegistry
-                        .getConfiguration(configName)
-                        .orElse(timeLimiterRegistry.getDefaultConfig()))
-                .circuitBreakerConfig(
-                    circuitBreakerRegistry
-                        .getConfiguration(configName)
-                        .orElse(circuitBreakerRegistry.getDefaultConfig()))
-                .build();
-          });
+      factory.configureDefault(id -> {
+        String configName = id.contains("write") || id.contains("cancel")
+            ? "default-write"
+            : id.contains("rollback") ? "default-rollback" : "default-read";
+
+        return new Resilience4JConfigBuilder(id)
+            .timeLimiterConfig(timeLimiterRegistry.getConfiguration(configName)
+                .orElse(timeLimiterRegistry.getDefaultConfig()))
+            .circuitBreakerConfig(circuitBreakerRegistry.getConfiguration(configName)
+                .orElse(circuitBreakerRegistry.getDefaultConfig()))
+            .build();
+      });
     };
   }
 }

--- a/src/main/java/com/goggles/orderservice/presentation/controller/OrderController.java
+++ b/src/main/java/com/goggles/orderservice/presentation/controller/OrderController.java
@@ -6,6 +6,9 @@ import com.goggles.orderservice.application.dto.query.OrderListQuery;
 import com.goggles.orderservice.application.dto.result.OrderListResult;
 import com.goggles.orderservice.application.service.OrderCommandService;
 import com.goggles.orderservice.application.service.OrderQueryService;
+import com.goggles.orderservice.presentation.dto.CancelLectureOrderRequest;
+import com.goggles.orderservice.presentation.dto.CancelMentoringOrderRequest;
+import com.goggles.orderservice.presentation.dto.CancelOrderResponse;
 import com.goggles.orderservice.presentation.dto.CreateLectureOrderRequest;
 import com.goggles.orderservice.presentation.dto.CreateMentoringOrderRequest;
 import com.goggles.orderservice.presentation.dto.CreateOrderResponse;
@@ -71,5 +74,23 @@ public class OrderController {
       @Valid @RequestBody CreateLectureOrderRequest request) {
     return CreateOrderResponse.from(
         orderCommandService.createLectureOrder(request.toCommand(userId, userRole)));
+  }
+
+  @PostMapping("/mentoring/cancellation")
+  public CancelOrderResponse cancelMentoringOrder(
+      @RequestHeader("X-User-Id") UUID userId,
+      @RequestHeader("X-User-Role") String userRole,
+      @Valid @RequestBody CancelMentoringOrderRequest request) {
+    return CancelOrderResponse.from(
+        orderCommandService.cancelMentoringOrder(request.toCommand(userId, userRole)));
+  }
+
+  @PostMapping("/lecture/cancellation")
+  public CancelOrderResponse cancelLectureOrder(
+      @RequestHeader("X-User-Id") UUID userId,
+      @RequestHeader("X-User-Role") String userRole,
+      @Valid @RequestBody CancelLectureOrderRequest request) {
+    return CancelOrderResponse.from(
+        orderCommandService.cancelLectureOrder(request.toCommand(userId, userRole)));
   }
 }

--- a/src/main/java/com/goggles/orderservice/presentation/dto/CancelLectureOrderRequest.java
+++ b/src/main/java/com/goggles/orderservice/presentation/dto/CancelLectureOrderRequest.java
@@ -1,0 +1,19 @@
+package com.goggles.orderservice.presentation.dto;
+
+import com.goggles.orderservice.application.common.UserRole;
+import com.goggles.orderservice.application.dto.command.CancelLectureOrderCommand;
+import java.util.List;
+import java.util.UUID;
+
+public record CancelLectureOrderRequest(
+    UUID orderId, List<UUID> enrollmentIds, String cancelReason, String cancelDescription) {
+  public CancelLectureOrderCommand toCommand(UUID userId, String userRole) {
+    return new CancelLectureOrderCommand(
+        userId,
+        UserRole.from(userRole),
+        this.orderId,
+        this.enrollmentIds,
+        this.cancelReason,
+        this.cancelDescription);
+  }
+}

--- a/src/main/java/com/goggles/orderservice/presentation/dto/CancelLectureOrderRequest.java
+++ b/src/main/java/com/goggles/orderservice/presentation/dto/CancelLectureOrderRequest.java
@@ -2,11 +2,18 @@ package com.goggles.orderservice.presentation.dto;
 
 import com.goggles.orderservice.application.common.UserRole;
 import com.goggles.orderservice.application.dto.command.CancelLectureOrderCommand;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import java.util.List;
 import java.util.UUID;
 
 public record CancelLectureOrderRequest(
-    UUID orderId, List<UUID> enrollmentIds, String cancelReason, String cancelDescription) {
+    @NotNull(message = "주문 ID는 필수입니다.") UUID orderId,
+    @NotNull(message = "등록 ID는 필수입니다.") @Size(min = 1, message = "등록 ID는 최소 1개 이상이어야 합니다.")
+        List<@NotNull(message = "등록 ID 값은 null일 수 없습니다.") UUID> enrollmentIds,
+    @NotBlank(message = "취소 이유는 필수입니다.") String cancelReason,
+    String cancelDescription) {
   public CancelLectureOrderCommand toCommand(UUID userId, String userRole) {
     return new CancelLectureOrderCommand(
         userId,

--- a/src/main/java/com/goggles/orderservice/presentation/dto/CancelMentoringOrderRequest.java
+++ b/src/main/java/com/goggles/orderservice/presentation/dto/CancelMentoringOrderRequest.java
@@ -2,10 +2,15 @@ package com.goggles.orderservice.presentation.dto;
 
 import com.goggles.orderservice.application.common.UserRole;
 import com.goggles.orderservice.application.dto.command.CancelMentoringOrderCommand;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import java.util.UUID;
 
 public record CancelMentoringOrderRequest(
-    UUID orderId, UUID enrollmentId, String cancelReason, String cancelDescription) {
+    @NotNull(message = "주문 ID는 필수입니다.") UUID orderId,
+    @NotNull(message = "예약 ID는 필수입니다.") UUID enrollmentId,
+    @NotBlank(message = "취소 이유는 필수입니다.") String cancelReason,
+    String cancelDescription) {
   public CancelMentoringOrderCommand toCommand(UUID userId, String userRole) {
     return new CancelMentoringOrderCommand(
         userId,

--- a/src/main/java/com/goggles/orderservice/presentation/dto/CancelMentoringOrderRequest.java
+++ b/src/main/java/com/goggles/orderservice/presentation/dto/CancelMentoringOrderRequest.java
@@ -1,0 +1,18 @@
+package com.goggles.orderservice.presentation.dto;
+
+import com.goggles.orderservice.application.common.UserRole;
+import com.goggles.orderservice.application.dto.command.CancelMentoringOrderCommand;
+import java.util.UUID;
+
+public record CancelMentoringOrderRequest(
+    UUID orderId, UUID enrollmentId, String cancelReason, String cancelDescription) {
+  public CancelMentoringOrderCommand toCommand(UUID userId, String userRole) {
+    return new CancelMentoringOrderCommand(
+        userId,
+        UserRole.from(userRole),
+        this.orderId,
+        this.enrollmentId,
+        this.cancelReason,
+        this.cancelDescription);
+  }
+}

--- a/src/main/java/com/goggles/orderservice/presentation/dto/CancelOrderResponse.java
+++ b/src/main/java/com/goggles/orderservice/presentation/dto/CancelOrderResponse.java
@@ -1,0 +1,10 @@
+package com.goggles.orderservice.presentation.dto;
+
+import com.goggles.orderservice.application.dto.result.CancelOrderResult;
+import java.util.UUID;
+
+public record CancelOrderResponse(UUID orderId, Long refundPrice) {
+  public static CancelOrderResponse from(CancelOrderResult result) {
+    return new CancelOrderResponse(result.orderId(), result.refundPrice());
+  }
+}

--- a/src/main/java/com/goggles/orderservice/presentation/dto/CreateOrderResponse.java
+++ b/src/main/java/com/goggles/orderservice/presentation/dto/CreateOrderResponse.java
@@ -3,8 +3,8 @@ package com.goggles.orderservice.presentation.dto;
 import com.goggles.orderservice.application.dto.result.CreateOrderResult;
 import java.util.UUID;
 
-public record CreateOrderResponse(UUID orderId, UUID studentId) {
+public record CreateOrderResponse(UUID orderId, Long orderPrice, String productName) {
   public static CreateOrderResponse from(CreateOrderResult result) {
-    return new CreateOrderResponse(result.orderId(), result.studentId());
+    return new CreateOrderResponse(result.orderId(), result.orderPrice(), result.productName());
   }
 }

--- a/src/test/java/com/goggles/orderservice/application/OrderCommandServiceTest.java
+++ b/src/test/java/com/goggles/orderservice/application/OrderCommandServiceTest.java
@@ -6,9 +6,9 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
-import static org.mockito.Mockito.mock;
 
 import com.goggles.orderservice.application.common.UserRole;
+import com.goggles.orderservice.application.dto.command.CancelLectureOrderCommand;
 import com.goggles.orderservice.application.dto.command.CreateLectureOrderCommand;
 import com.goggles.orderservice.application.dto.command.CreateMentoringOrderCommand;
 import com.goggles.orderservice.application.dto.external.ProductReserveInfo;
@@ -20,12 +20,17 @@ import com.goggles.orderservice.application.port.out.UserReader;
 import com.goggles.orderservice.application.service.impl.OrderCommandServiceImpl;
 import com.goggles.orderservice.domain.event.OrderEvents;
 import com.goggles.orderservice.domain.event.OrderPaymentPendingEvent;
+import com.goggles.orderservice.domain.exception.NotFoundOrderException;
+import com.goggles.orderservice.domain.model.CancelReason;
 import com.goggles.orderservice.domain.model.Order;
+import com.goggles.orderservice.domain.model.OrderItemType;
+import com.goggles.orderservice.domain.model.OrderPrice;
 import com.goggles.orderservice.domain.model.Orderer;
 import com.goggles.orderservice.domain.repository.OrderRepository;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -50,18 +55,18 @@ class OrderCommandServiceTest {
   private final UUID COUPON_ID = UUID.randomUUID();
   private final UUID LECTURE_ID = UUID.randomUUID();
   private final UUID MENTORING_ID = UUID.randomUUID();
+  private final UUID ENROLLMENT_ID = UUID.randomUUID();
   private final UUID ORDER_ID = UUID.randomUUID();
-  private final String USER_ROLE = "STUDENT";
-  private final String USER_NAME = "홍길동";
-  private final String USER_EMAIL = "hello1@naver.com";
 
   private UserInfo userInfo() {
+    String USER_NAME = "홍길동";
+    String USER_EMAIL = "hello1@naver.com";
     return new UserInfo(USER_ID, USER_NAME, USER_EMAIL);
   }
 
   private ProductReserveInfo lectureProductReserveInfo() {
     return new ProductReserveInfo(
-        UUID.randomUUID(), LECTURE_ID, "자바 강의", 10000L, UUID.randomUUID(), "강사A");
+        ENROLLMENT_ID, LECTURE_ID, "자바 강의", 10000L, UUID.randomUUID(), "강사A");
   }
 
   private ProductReserveInfo mentoringProductReserveInfo() {
@@ -69,72 +74,74 @@ class OrderCommandServiceTest {
         UUID.randomUUID(), MENTORING_ID, "멘토링", 50000L, UUID.randomUUID(), "멘토A");
   }
 
-  private Order mockOrder() {
-    Order order = mock(Order.class);
-    given(order.getId()).willReturn(ORDER_ID);
-    given(order.getOrderer()).willReturn(new Orderer(USER_ID, USER_NAME, USER_EMAIL));
-    return order;
+  private Order createLectureOrderEntity() {
+    UserInfo user = userInfo();
+    ProductReserveInfo product = lectureProductReserveInfo();
+    return Order.create(
+        new Orderer(user.userId(), user.userName(), user.userEmail()),
+        null,
+        new OrderPrice(product.productPrice(), 0L),
+        List.of(product.toOrderItemSpec(OrderItemType.LECTURE)),
+        orderEvents);
+  }
+
+  private Order createMentoringOrderEntity() {
+    UserInfo user = userInfo();
+    ProductReserveInfo product = mentoringProductReserveInfo();
+    return Order.create(
+        new Orderer(user.userId(), user.userName(), user.userEmail()),
+        null,
+        new OrderPrice(product.productPrice(), 0L),
+        product.toOrderItemSpec(OrderItemType.MENTORING),
+        orderEvents);
+  }
+
+  private CreateLectureOrderCommand lectureCommand() {
+    return new CreateLectureOrderCommand(
+        USER_ID, UserRole.STUDENT, COUPON_ID, "CARD", List.of(LECTURE_ID));
   }
 
   @Nested
   @DisplayName("강의 주문 생성")
   class CreateLectureOrder {
 
-    private CreateLectureOrderCommand command() {
-      return new CreateLectureOrderCommand(
-          USER_ID, UserRole.from(USER_ROLE), COUPON_ID, "CARD", List.of(LECTURE_ID));
-    }
-
     @Test
-    @DisplayName("성공: 정상적으로 강의 주문이 생성된다")
-    void success() {
+    @DisplayName("성공: 실제 도메인 로직을 거쳐 주문이 생성되고 이벤트가 발행된다")
+    void successWithDomainLogic() {
       // given
-      ProductReserveInfo productInfo = lectureProductReserveInfo();
-      Order order = mockOrder();
+      ProductReserveInfo reserveInfo =
+          new ProductReserveInfo(
+              ENROLLMENT_ID, LECTURE_ID, "자바 강의", 10000L, UUID.randomUUID(), "강사A");
 
       given(userReader.getUserInfo(USER_ID)).willReturn(userInfo());
-      given(lectureProvider.reserveEnrollment(any())).willReturn(List.of(productInfo));
-      given(orderRepository.createOrder(any())).willReturn(order);
+      given(lectureProvider.reserveEnrollment(any())).willReturn(List.of(reserveInfo));
+      given(orderRepository.createOrder(any(Order.class)))
+          .willAnswer(invocation -> invocation.getArgument(0));
 
       // when
-      CreateOrderResult result = orderCommandService.createLectureOrder(command());
+      CreateOrderResult result = orderCommandService.createLectureOrder(lectureCommand());
 
       // then
-      assertThat(result.orderId()).isEqualTo(ORDER_ID);
-      assertThat(result.studentId()).isEqualTo(USER_ID);
-
-      then(userReader).should().getUserInfo(USER_ID);
-      then(lectureProvider).should().reserveEnrollment(any());
-      then(orderRepository).should().createOrder(any());
-
+      assertThat(result).isNotNull();
       then(orderEvents).should().orderPaymentPending(any(OrderPaymentPendingEvent.class));
+      then(orderRepository).should().createOrder(any(Order.class));
     }
 
     @Test
-    @DisplayName("성공: 여러 강의 주문 시 총 가격이 합산된다")
-    void totalPriceSummed() {
+    @DisplayName("보상 트랜잭션: DB 저장 실패 시 이미 예약된 강의를 롤백한다")
+    void rollbackWhenRepositoryFails() {
       // given
-      ProductReserveInfo info1 =
-          new ProductReserveInfo(
-              UUID.randomUUID(), UUID.randomUUID(), "강의A", 10000L, UUID.randomUUID(), "강사A");
-      ProductReserveInfo info2 =
-          new ProductReserveInfo(
-              UUID.randomUUID(), UUID.randomUUID(), "강의B", 20000L, UUID.randomUUID(), "강사B");
-      Order order = mockOrder();
-
       given(userReader.getUserInfo(USER_ID)).willReturn(userInfo());
-      given(lectureProvider.reserveEnrollment(any())).willReturn(List.of(info1, info2));
-      given(orderRepository.createOrder(any())).willReturn(order);
+      given(lectureProvider.reserveEnrollment(any()))
+          .willReturn(List.of(lectureProductReserveInfo()));
+      given(orderRepository.createOrder(any())).willThrow(new RuntimeException("DB Error"));
 
-      // when
-      orderCommandService.createLectureOrder(command());
+      // when & then
+      assertThatThrownBy(() -> orderCommandService.createLectureOrder(lectureCommand()))
+          .isInstanceOf(RuntimeException.class);
 
-      // then - 총합 30000L로 Order.create 호출됐는지 검증
-      then(orderRepository)
-          .should()
-          .createOrder(argThat(o -> o.getPrice().getFinalPrice() == 30000L));
-
-      then(orderEvents).should().orderPaymentPending(any(OrderPaymentPendingEvent.class));
+      // 보상 트랜잭션 호출 여부만 검증 (이벤트는 Order.create 시점에 이미 발행되므로 이 테스트의 관심사 아님)
+      then(lectureProvider).should().rollbackLectureEnrollment(any());
     }
 
     @Test
@@ -144,7 +151,7 @@ class OrderCommandServiceTest {
       given(userReader.getUserInfo(USER_ID)).willThrow(new RuntimeException("유저 없음"));
 
       // when & then
-      assertThatThrownBy(() -> orderCommandService.createLectureOrder(command()))
+      assertThatThrownBy(() -> orderCommandService.createLectureOrder(lectureCommand()))
           .isInstanceOf(RuntimeException.class)
           .hasMessage("유저 없음");
 
@@ -160,10 +167,65 @@ class OrderCommandServiceTest {
       given(lectureProvider.reserveEnrollment(any())).willThrow(new RuntimeException("예약 실패"));
 
       // when & then
-      assertThatThrownBy(() -> orderCommandService.createLectureOrder(command()))
+      assertThatThrownBy(() -> orderCommandService.createLectureOrder(lectureCommand()))
           .isInstanceOf(RuntimeException.class);
 
       then(orderRepository).shouldHaveNoInteractions();
+    }
+  }
+
+  @Nested
+  @DisplayName("주문 취소")
+  class CancelOrder {
+
+    @Test
+    @DisplayName("성공: 강의 주문을 취소하면 외부 서비스 호출 후 주문 상태가 CANCELLED로 변경된다")
+    void cancelLectureSuccess() {
+      // given
+      CancelLectureOrderCommand command =
+          new CancelLectureOrderCommand(
+              USER_ID,
+              UserRole.STUDENT,
+              ORDER_ID,
+              List.of(ENROLLMENT_ID),
+              CancelReason.USER_CANCEL.name(),
+              "그냥요");
+
+      Order order = createLectureOrderEntity();
+
+      given(userReader.getUserInfo(USER_ID)).willReturn(userInfo());
+      given(orderRepository.getOrderByIdAndUserId(ORDER_ID, USER_ID))
+          .willReturn(Optional.of(order));
+
+      // when
+      orderCommandService.cancelLectureOrder(command);
+
+      // then: 외부 서비스 호출 검증
+      then(lectureProvider).should().cancelLectureEnrollment(any());
+      // then: 도메인 상태 변경 검증 (실제 도메인 객체이므로 상태로 검증)
+      assertThat(order.getCanceledAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("실패: 주문이 존재하지 않으면 예외가 발생하고 외부 서비스는 호출되지 않는다")
+    void cancelFailWhenOrderNotFound() {
+      // given
+      CancelLectureOrderCommand command =
+          new CancelLectureOrderCommand(
+              USER_ID,
+              UserRole.STUDENT,
+              ORDER_ID,
+              List.of(ENROLLMENT_ID),
+              CancelReason.USER_CANCEL.name(),
+              "그냥요");
+      given(userReader.getUserInfo(USER_ID)).willReturn(userInfo());
+      given(orderRepository.getOrderByIdAndUserId(ORDER_ID, USER_ID)).willReturn(Optional.empty());
+
+      // when & then
+      assertThatThrownBy(() -> orderCommandService.cancelLectureOrder(command))
+          .isInstanceOf(NotFoundOrderException.class);
+
+      then(lectureProvider).shouldHaveNoInteractions();
     }
   }
 
@@ -172,6 +234,7 @@ class OrderCommandServiceTest {
   class CreateMentoringOrder {
 
     private CreateMentoringOrderCommand command() {
+      String USER_ROLE = "STUDENT";
       return new CreateMentoringOrderCommand(
           USER_ID,
           UserRole.from(USER_ROLE),
@@ -189,23 +252,20 @@ class OrderCommandServiceTest {
     void success() {
       // given
       ProductReserveInfo productInfo = mentoringProductReserveInfo();
-      Order order = mockOrder();
 
       given(userReader.getUserInfo(USER_ID)).willReturn(userInfo());
       given(mentoringProvider.reserveEnrollment(any())).willReturn(productInfo);
-      given(orderRepository.createOrder(any())).willReturn(order);
+      // createOrder에 전달된 실제 Order를 그대로 반환
+      given(orderRepository.createOrder(any())).willAnswer(inv -> inv.getArgument(0));
 
       // when
       CreateOrderResult result = orderCommandService.createMentoringOrder(command());
 
       // then
-      assertThat(result.orderId()).isEqualTo(ORDER_ID);
-      assertThat(result.studentId()).isEqualTo(USER_ID);
-
+      assertThat(result).isNotNull();
       then(userReader).should().getUserInfo(USER_ID);
       then(mentoringProvider).should().reserveEnrollment(any());
       then(orderRepository).should().createOrder(any());
-
       then(orderEvents).should().orderPaymentPending(any(OrderPaymentPendingEvent.class));
     }
 
@@ -214,25 +274,23 @@ class OrderCommandServiceTest {
     void singleItemPrice() {
       // given
       ProductReserveInfo productInfo = mentoringProductReserveInfo(); // 50000L
-      Order order = mockOrder();
 
       given(userReader.getUserInfo(USER_ID)).willReturn(userInfo());
       given(mentoringProvider.reserveEnrollment(any())).willReturn(productInfo);
-      given(orderRepository.createOrder(any())).willReturn(order);
+      given(orderRepository.createOrder(any())).willAnswer(inv -> inv.getArgument(0));
 
       // when
       orderCommandService.createMentoringOrder(command());
 
-      // then
+      // then: createOrder에 전달된 Order의 실제 price 검증
       then(orderRepository)
           .should()
           .createOrder(argThat(o -> o.getPrice().getFinalPrice() == 50000L));
-
       then(orderEvents).should().orderPaymentPending(any(OrderPaymentPendingEvent.class));
     }
 
     @Test
-    @DisplayName("실패: 멘토링 예약 실패 시 예외가 전파된다")
+    @DisplayName("실패: 멘토링 예약 실패 시 보상 트랜잭션이 호출되고 예외가 전파된다")
     void reservationFailed() {
       // given
       given(userReader.getUserInfo(USER_ID)).willReturn(userInfo());
@@ -243,6 +301,23 @@ class OrderCommandServiceTest {
           .isInstanceOf(RuntimeException.class);
 
       then(orderRepository).shouldHaveNoInteractions();
+    }
+
+    @Test
+    @DisplayName("보상 트랜잭션: DB 저장 실패 시 멘토링 예약을 롤백한다")
+    void rollbackWhenRepositoryFails() {
+      // given
+      ProductReserveInfo productInfo = mentoringProductReserveInfo();
+
+      given(userReader.getUserInfo(USER_ID)).willReturn(userInfo());
+      given(mentoringProvider.reserveEnrollment(any())).willReturn(productInfo);
+      given(orderRepository.createOrder(any())).willThrow(new RuntimeException("DB Error"));
+
+      // when & then
+      assertThatThrownBy(() -> orderCommandService.createMentoringOrder(command()))
+          .isInstanceOf(RuntimeException.class);
+
+      then(mentoringProvider).should().rollbackMentoringBooking(any());
     }
   }
 }


### PR DESCRIPTION
### 📌 관련 이슈
- close #15 

### 💡 작업 내용
- 강의/멘토링 주문 취소 API 구현
- 주문 취소 시 강의/멘토링 서비스 호출과 Rollback 호출을 분리하여 책임 분리
- Rollback 요청에 대해 Resilience4J TimeLimiter 설정 추가
- 주문 취소 흐름에 대한 테스트 코드 작성

### 🔍 변경 이유
- 주문 취소 시 외부 서비스(강의/멘토링) 호출 실패에 대비한 롤백 처리 필요
- 기존 구조에서는 취소 실패 시 상태 불일치 가능성이 존재하여 안정성 개선 필요
- Rollback 로직을 분리하여 장애 상황에서도 유연하게 대응할 수 있도록 구조 개선
- 외부 API 지연 및 장애에 대비하여 TimeLimiter를 적용해 응답 지연 제어

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **New Features**
  * 강의 주문 취소 API 추가: 주문 ID, 등록 ID, 취소 사유와 설명을 통해 취소 가능
  * 멘토링 주문 취소 API 추가: 주문 ID, 예약 ID, 취소 사유와 설명을 통해 취소 가능
  * 주문 취소 시 주문 ID와 환불 금액 반환

* **Changes**
  * 주문 생성 응답 정보 변경: 학생 ID 대신 상품명과 주문 가격 제공

<!-- end of auto-generated comment: release notes by coderabbit.ai -->